### PR TITLE
Worker uses client to make a connection

### DIFF
--- a/evictiontest/workflow_cache_eviction_test.go
+++ b/evictiontest/workflow_cache_eviction_test.go
@@ -157,7 +157,9 @@ func (s *CacheEvictionSuite) TestResetStickyOnEviction() {
 	// so if our worker puts *cacheSize* entries in the cache, it should evict exactly one
 	s.service.EXPECT().ResetStickyTaskList(gomock.Any(), gomock.Any()).DoAndReturn(mockResetStickyTaskList).Times(1)
 
-	workflowWorker := internal.NewAggregatedWorker(s.service, nil, "tasklist", worker.Options{DisableActivityWorker: true})
+	client := internal.newServiceClient(s.service, nil, internal.ClientOptions{})
+
+	workflowWorker := internal.NewAggregatedWorker(client, "tasklist", worker.Options{DisableActivityWorker: true})
 	// this is an arbitrary workflow we use for this test
 	// NOTE: a simple helloworld that doesn't execute an activity
 	// won't work because the workflow will simply just complete

--- a/evictiontest/workflow_cache_eviction_test.go
+++ b/evictiontest/workflow_cache_eviction_test.go
@@ -157,7 +157,7 @@ func (s *CacheEvictionSuite) TestResetStickyOnEviction() {
 	// so if our worker puts *cacheSize* entries in the cache, it should evict exactly one
 	s.service.EXPECT().ResetStickyTaskList(gomock.Any(), gomock.Any()).DoAndReturn(mockResetStickyTaskList).Times(1)
 
-	client := internal.newServiceClient(s.service, nil, internal.ClientOptions{})
+	client := internal.NewServiceClient(s.service, nil, internal.ClientOptions{})
 
 	workflowWorker := internal.NewAggregatedWorker(client, "tasklist", worker.Options{DisableActivityWorker: true})
 	// this is an arbitrary workflow we use for this test

--- a/internal/client.go
+++ b/internal/client.go
@@ -568,7 +568,7 @@ func NewClient(options ClientOptions) (Client, error) {
 }
 
 // NewServiceClient creates workflow client from workflowservice.WorkflowServiceClient. Must be used internally in unit tests only.
-func NewServiceClient(workflowServiceClient workflowservice.WorkflowServiceClient, connectionCloser io.Closer, options ClientOptions) *workflowClient {
+func NewServiceClient(workflowServiceClient workflowservice.WorkflowServiceClient, connectionCloser io.Closer, options ClientOptions) *WorkflowClient {
 	// DomainName can be empty in unit tests.
 	if len(options.DomainName) == 0 {
 		options.DomainName = DefaultDomainName
@@ -588,7 +588,7 @@ func NewServiceClient(workflowServiceClient workflowservice.WorkflowServiceClien
 		options.Tracer = opentracing.NoopTracer{}
 	}
 
-	return &workflowClient{
+	return &WorkflowClient{
 		workflowService:    workflowServiceClient,
 		connectionCloser:   connectionCloser,
 		domain:             options.DomainName,

--- a/internal/client.go
+++ b/internal/client.go
@@ -564,10 +564,11 @@ func NewClient(options ClientOptions) (Client, error) {
 		return nil, err
 	}
 
-	return newServiceClient(workflowservice.NewWorkflowServiceClient(connection), connection, options), nil
+	return NewServiceClient(workflowservice.NewWorkflowServiceClient(connection), connection, options), nil
 }
 
-func newServiceClient(workflowServiceClient workflowservice.WorkflowServiceClient, connectionCloser io.Closer, options ClientOptions) Client {
+// NewServiceClient creates workflow client from workflowservice.WorkflowServiceClient. Must be used internally in unit tests only.
+func NewServiceClient(workflowServiceClient workflowservice.WorkflowServiceClient, connectionCloser io.Closer, options ClientOptions) *workflowClient {
 	// DomainName can be empty in unit tests.
 	if len(options.DomainName) == 0 {
 		options.DomainName = DefaultDomainName

--- a/internal/client.go
+++ b/internal/client.go
@@ -544,7 +544,7 @@ func NewClient(options ClientOptions) (Client, error) {
 		options.DomainName = DefaultDomainName
 	}
 
-	metricsScope := tagScope(options.MetricsScope, tagDomain, options.DomainName, clientImplHeaderName, clientImplHeaderValue)
+	options.MetricsScope = tagScope(options.MetricsScope, tagDomain, options.DomainName, clientImplHeaderName, clientImplHeaderValue)
 
 	if len(options.HostPort) == 0 {
 		options.HostPort = LocalHostPort
@@ -556,7 +556,7 @@ func NewClient(options ClientOptions) (Client, error) {
 
 	connection, err := options.GRPCDialer(GRPCDialerParams{
 		HostPort:             options.HostPort,
-		RequiredInterceptors: requiredInterceptors(metricsScope),
+		RequiredInterceptors: requiredInterceptors(options.MetricsScope),
 		DefaultServiceConfig: defaultServiceConfig,
 	})
 
@@ -568,11 +568,10 @@ func NewClient(options ClientOptions) (Client, error) {
 }
 
 func newServiceClient(workflowServiceClient workflowservice.WorkflowServiceClient, connectionCloser io.Closer, options ClientOptions) Client {
+	// DomainName can be empty in unit tests.
 	if len(options.DomainName) == 0 {
 		options.DomainName = DefaultDomainName
 	}
-
-	options.MetricsScope = tagScope(options.MetricsScope, tagDomain, options.DomainName, clientImplHeaderName, clientImplHeaderValue)
 
 	if len(options.Identity) == 0 {
 		options.Identity = getWorkerIdentity("")
@@ -603,7 +602,7 @@ func newServiceClient(workflowServiceClient workflowservice.WorkflowServiceClien
 
 // NewDomainClient creates an instance of a domain client, to manager lifecycle of domains.
 func NewDomainClient(options ClientOptions) (DomainClient, error) {
-	metricsScope := tagScope(options.MetricsScope, clientImplHeaderName, clientImplHeaderValue)
+	options.MetricsScope = tagScope(options.MetricsScope, clientImplHeaderName, clientImplHeaderValue)
 
 	if len(options.HostPort) == 0 {
 		options.HostPort = LocalHostPort
@@ -615,7 +614,7 @@ func NewDomainClient(options ClientOptions) (DomainClient, error) {
 
 	connection, err := options.GRPCDialer(GRPCDialerParams{
 		HostPort:             options.HostPort,
-		RequiredInterceptors: requiredInterceptors(metricsScope),
+		RequiredInterceptors: requiredInterceptors(options.MetricsScope),
 		DefaultServiceConfig: defaultServiceConfig,
 	})
 
@@ -631,12 +630,10 @@ func newDomainServiceClient(workflowServiceClient workflowservice.WorkflowServic
 		options.Identity = getWorkerIdentity("")
 	}
 
-	metricsScope := tagScope(options.MetricsScope, tagDomain, "domain-client", clientImplHeaderName, clientImplHeaderValue)
-
 	return &domainClient{
 		workflowService:  workflowServiceClient,
 		connectionCloser: clientConn,
-		metricsScope:     metricsScope,
+		metricsScope:     options.MetricsScope,
 		identity:         options.Identity,
 	}
 }

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -437,8 +437,8 @@ func Test_ContinueAsNewError(t *testing.T) {
 	}
 
 	s := &WorkflowTestSuite{
-		header:   header,
-		ctxProps: []ContextPropagator{NewStringMapPropagator([]string{"test"})},
+		header:             header,
+		contextPropagators: []ContextPropagator{NewStringMapPropagator([]string{"test"})},
 	}
 	wfEnv := s.NewTestWorkflowEnvironment()
 	wfEnv.RegisterWorkflowWithOptions(continueAsNewWorkflowFn, RegisterWorkflowOptions{

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -1717,7 +1717,7 @@ func (i *temporalInvoker) Close(flushBufferedHeartbeat bool) {
 }
 
 func (i *temporalInvoker) GetClient(domain string, options ClientOptions) Client {
-	return newServiceClient(i.service, nil, options)
+	return NewServiceClient(i.service, nil, options)
 }
 
 func newServiceInvoker(

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1492,10 +1492,6 @@ func getReadOnlyChannel(c chan struct{}) <-chan struct{} {
 }
 
 func augmentWorkerOptions(options WorkerOptions) WorkerOptions {
-	if len(options.domainName) == 0 {
-		options.domainName = DefaultDomainName
-	}
-
 	if options.MaxConcurrentActivityExecutionSize == 0 {
 		options.MaxConcurrentActivityExecutionSize = defaultMaxConcurrentActivityExecutionSize
 	}
@@ -1520,17 +1516,18 @@ func augmentWorkerOptions(options WorkerOptions) WorkerOptions {
 	if options.StickyScheduleToStartTimeout.Seconds() == 0 {
 		options.StickyScheduleToStartTimeout = stickyDecisionScheduleToStartTimeoutSeconds * time.Second
 	}
-	if options.dataConverter == nil {
-		options.dataConverter = getDefaultDataConverter()
-	}
 	if options.MaxConcurrentSessionExecutionSize == 0 {
 		options.MaxConcurrentSessionExecutionSize = defaultMaxConcurrentSessionExecutionSize
 	}
 
-	// if the user passes in a tracer then add a tracing context propagator
-	if options.tracer != nil {
-		options.contextPropagators = append(options.contextPropagators, NewTracingContextPropagator(options.Logger, options.tracer))
-	} else {
+	// Private options can be nil only in unit tests.
+	if options.dataConverter == nil {
+		options.dataConverter = getDefaultDataConverter()
+	}
+	if len(options.domainName) == 0 {
+		options.domainName = DefaultDomainName
+	}
+	if options.tracer == nil {
 		options.tracer = opentracing.NoopTracer{}
 	}
 	return options

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1319,7 +1319,7 @@ func extractHistoryFromFile(jsonfileName string, lastEventID int64) (*commonprot
 // NewAggregatedWorker returns an instance to manage the workers. Use defaultConcurrentPollRoutineSize (which is 2) as
 // poller size. The typical RTT (round-trip time) is below 1ms within data center. And the poll API latency is about 5ms.
 // With 2 poller, we could achieve around 300~400 RPS.
-func NewAggregatedWorker(client *workflowClient, taskList string, options WorkerOptions) *AggregatedWorker {
+func NewAggregatedWorker(client *WorkflowClient, taskList string, options WorkerOptions) *AggregatedWorker {
 	setClientDefaults(client)
 	setWorkerOptionsDefaults(&options)
 	ctx := options.BackgroundActivityContext
@@ -1522,7 +1522,7 @@ func setWorkerOptionsDefaults(options *WorkerOptions) {
 	}
 }
 
-func setClientDefaults(client *workflowClient) {
+func setClientDefaults(client *WorkflowClient) {
 	// This should be needed only in unit tests.
 	if client.dataConverter == nil {
 		client.dataConverter = getDefaultDataConverter()

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1320,8 +1320,8 @@ func extractHistoryFromFile(jsonfileName string, lastEventID int64) (*commonprot
 // poller size. The typical RTT (round-trip time) is below 1ms within data center. And the poll API latency is about 5ms.
 // With 2 poller, we could achieve around 300~400 RPS.
 func NewAggregatedWorker(client *workflowClient, taskList string, options WorkerOptions) *AggregatedWorker {
-	augmentClient(client)
-	augmentWorkerOptions(&options)
+	setClientDefaults(client)
+	setWorkerOptionsDefaults(&options)
 	ctx := options.BackgroundActivityContext
 	if ctx == nil {
 		ctx = context.Background()
@@ -1492,7 +1492,7 @@ func getReadOnlyChannel(c chan struct{}) <-chan struct{} {
 	return c
 }
 
-func augmentWorkerOptions(options *WorkerOptions) {
+func setWorkerOptionsDefaults(options *WorkerOptions) {
 	if options.MaxConcurrentActivityExecutionSize == 0 {
 		options.MaxConcurrentActivityExecutionSize = defaultMaxConcurrentActivityExecutionSize
 	}
@@ -1522,7 +1522,7 @@ func augmentWorkerOptions(options *WorkerOptions) {
 	}
 }
 
-func augmentClient(client *workflowClient) {
+func setClientDefaults(client *workflowClient) {
 	// This should be needed only in unit tests.
 	if client.dataConverter == nil {
 		client.dataConverter = getDefaultDataConverter()

--- a/internal/internal_worker_interfaces_test.go
+++ b/internal/internal_worker_interfaces_test.go
@@ -225,7 +225,7 @@ func (s *InterfacesTestSuite) TestInterface() {
 		ExecutionStartToCloseTimeout:    10 * time.Second,
 		DecisionTaskStartToCloseTimeout: 10 * time.Second,
 	}
-	workflowClient := newServiceClient(s.service, nil, ClientOptions{})
+	workflowClient := NewServiceClient(s.service, nil, ClientOptions{})
 	_, err := workflowClient.ExecuteWorkflow(context.Background(), workflowOptions, "workflowType")
 	s.NoError(err)
 }

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -581,17 +581,20 @@ func createWorkerWithThrottle(
 	service.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	// Configure worker options.
-	workerOptions := WorkerOptions{}
-	workerOptions.domainName = domain
-	workerOptions.WorkerActivitiesPerSecond = 20
-	workerOptions.TaskListActivitiesPerSecond = activitiesPerSecond
-	if dc != nil {
-		workerOptions.dataConverter = dc
-	}
-	workerOptions.EnableSessionWorker = true
+	workerOptions := WorkerOptions{
+		WorkerActivitiesPerSecond:   20,
+		TaskListActivitiesPerSecond: activitiesPerSecond,
+		EnableSessionWorker:         true}
 
-	// Start Worker.
-	worker := NewAggregatedWorker(service, "testGroupName2", workerOptions)
+	clientOptions := ClientOptions{
+		DomainName: domain,
+	}
+	if dc != nil {
+		clientOptions.DataConverter = dc
+	}
+
+	client := NewServiceClient(service, nil, clientOptions)
+	worker := NewAggregatedWorker(client, "testGroupName2", workerOptions)
 	return worker
 }
 
@@ -602,7 +605,7 @@ func createWorkerWithDataConverter(service *workflowservicemock.MockWorkflowServ
 func (s *internalWorkerTestSuite) testCompleteActivityHelper(opt ClientOptions) {
 	t := s.T()
 	mockService := s.service
-	wfClient := newServiceClient(mockService, nil, opt)
+	wfClient := NewServiceClient(mockService, nil, opt)
 	var completedRequest, canceledRequest, failedRequest interface{}
 	mockService.EXPECT().RespondActivityTaskCompleted(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.RespondActivityTaskCompletedResponse{}, nil).Do(
 		func(ctx context.Context, request *workflowservice.RespondActivityTaskCompletedRequest, opts ...grpc.CallOption) {
@@ -639,7 +642,7 @@ func (s *internalWorkerTestSuite) TestCompleteActivity_WithDataConverter() {
 func (s *internalWorkerTestSuite) TestCompleteActivityById() {
 	t := s.T()
 	mockService := s.service
-	wfClient := newServiceClient(mockService, nil, ClientOptions{DomainName: "testDomain"})
+	wfClient := NewServiceClient(mockService, nil, ClientOptions{DomainName: "testDomain"})
 	var completedRequest, canceledRequest, failedRequest interface{}
 	mockService.EXPECT().RespondActivityTaskCompletedByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(&workflowservice.RespondActivityTaskCompletedByIDResponse{}, nil).Do(
 		func(ctx context.Context, request *workflowservice.RespondActivityTaskCompletedByIDRequest, opts ...grpc.CallOption) {
@@ -669,7 +672,7 @@ func (s *internalWorkerTestSuite) TestCompleteActivityById() {
 }
 
 func (s *internalWorkerTestSuite) TestRecordActivityHeartbeat() {
-	wfClient := newServiceClient(s.service, nil, ClientOptions{DomainName: "testDomain"})
+	wfClient := NewServiceClient(s.service, nil, ClientOptions{DomainName: "testDomain"})
 	var heartbeatRequest *workflowservice.RecordActivityTaskHeartbeatRequest
 	heartbeatResponse := workflowservice.RecordActivityTaskHeartbeatResponse{CancelRequested: false}
 	s.service.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), gomock.Any(), gomock.Any()).Return(&heartbeatResponse, nil).
@@ -686,7 +689,7 @@ func (s *internalWorkerTestSuite) TestRecordActivityHeartbeat_WithDataConverter(
 	t := s.T()
 	dc := newTestDataConverter()
 	opt := ClientOptions{DomainName: "testDomain", DataConverter: dc}
-	wfClient := newServiceClient(s.service, nil, opt)
+	wfClient := NewServiceClient(s.service, nil, opt)
 	var heartbeatRequest *workflowservice.RecordActivityTaskHeartbeatRequest
 	heartbeatResponse := workflowservice.RecordActivityTaskHeartbeatResponse{CancelRequested: false}
 	detail1 := "testStack"
@@ -705,7 +708,7 @@ func (s *internalWorkerTestSuite) TestRecordActivityHeartbeat_WithDataConverter(
 }
 
 func (s *internalWorkerTestSuite) TestRecordActivityHeartbeatByID() {
-	wfClient := newServiceClient(s.service, nil, ClientOptions{DomainName: "testDomain"})
+	wfClient := NewServiceClient(s.service, nil, ClientOptions{DomainName: "testDomain"})
 	var heartbeatRequest *workflowservice.RecordActivityTaskHeartbeatByIDRequest
 	heartbeatResponse := workflowservice.RecordActivityTaskHeartbeatByIDResponse{CancelRequested: false}
 	s.service.EXPECT().RecordActivityTaskHeartbeatByID(gomock.Any(), gomock.Any(), gomock.Any()).Return(&heartbeatResponse, nil).
@@ -904,7 +907,7 @@ func testVariousActivitySchedulingOption(t *testing.T, wf interface{}) {
 func testVariousActivitySchedulingOptionWithDataConverter(t *testing.T, wf interface{}) {
 	ts := &WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
-	env.SetWorkerOptions(WorkerOptions{dataConverter: newTestDataConverter()})
+	env.SetDataConverter(newTestDataConverter())
 	env.RegisterWorkflow(wf)
 	testInternalWorkerRegisterWithTestEnv(env)
 	env.ExecuteWorkflow(wf, []byte{1, 2})

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -582,16 +582,16 @@ func createWorkerWithThrottle(
 
 	// Configure worker options.
 	workerOptions := WorkerOptions{}
-	workerOptions.DomainName = domain
+	workerOptions.domainName = domain
 	workerOptions.WorkerActivitiesPerSecond = 20
 	workerOptions.TaskListActivitiesPerSecond = activitiesPerSecond
 	if dc != nil {
-		workerOptions.DataConverter = dc
+		workerOptions.dataConverter = dc
 	}
 	workerOptions.EnableSessionWorker = true
 
 	// Start Worker.
-	worker := NewAggregatedWorker(service, nil, "testGroupName2", workerOptions)
+	worker := NewAggregatedWorker(service, "testGroupName2", workerOptions)
 	return worker
 }
 
@@ -904,7 +904,7 @@ func testVariousActivitySchedulingOption(t *testing.T, wf interface{}) {
 func testVariousActivitySchedulingOptionWithDataConverter(t *testing.T, wf interface{}) {
 	ts := &WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
-	env.SetWorkerOptions(WorkerOptions{DataConverter: newTestDataConverter()})
+	env.SetWorkerOptions(WorkerOptions{dataConverter: newTestDataConverter()})
 	env.RegisterWorkflow(wf)
 	testInternalWorkerRegisterWithTestEnv(env)
 	env.ExecuteWorkflow(wf, []byte{1, 2})

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -318,9 +318,13 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 	options := WorkerOptions{
 		Logger:                zap.NewNop(),
 		DisableActivityWorker: true,
-		identity:              "test-worker-identity",
 	}
-	worker := NewAggregatedWorker(s.service, taskList, options)
+	clientOptions := ClientOptions{
+		Identity: "test-worker-identity",
+	}
+
+	client := NewServiceClient(s.service, nil, clientOptions)
+	worker := NewAggregatedWorker(client, taskList, options)
 	worker.RegisterWorkflowWithOptions(
 		longDecisionWorkflowFn,
 		RegisterWorkflowOptions{Name: "long-running-decision-workflow-type"},
@@ -446,9 +450,13 @@ func (s *WorkersTestSuite) TestMultipleLocalActivities() {
 	options := WorkerOptions{
 		Logger:                zap.NewNop(),
 		DisableActivityWorker: true,
-		identity:              "test-worker-identity",
 	}
-	worker := NewAggregatedWorker(s.service, taskList, options)
+	clientOptions := ClientOptions{
+		Identity: "test-worker-identity",
+	}
+
+	client := NewServiceClient(s.service, nil, clientOptions)
+	worker := NewAggregatedWorker(client, taskList, options)
 	worker.RegisterWorkflowWithOptions(
 		longDecisionWorkflowFn,
 		RegisterWorkflowOptions{Name: "multiple-local-activities-workflow-type"},

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -318,9 +318,9 @@ func (s *WorkersTestSuite) TestLongRunningDecisionTask() {
 	options := WorkerOptions{
 		Logger:                zap.NewNop(),
 		DisableActivityWorker: true,
-		Identity:              "test-worker-identity",
+		identity:              "test-worker-identity",
 	}
-	worker := NewAggregatedWorker(s.service, nil, taskList, options)
+	worker := NewAggregatedWorker(s.service, taskList, options)
 	worker.RegisterWorkflowWithOptions(
 		longDecisionWorkflowFn,
 		RegisterWorkflowOptions{Name: "long-running-decision-workflow-type"},
@@ -446,9 +446,9 @@ func (s *WorkersTestSuite) TestMultipleLocalActivities() {
 	options := WorkerOptions{
 		Logger:                zap.NewNop(),
 		DisableActivityWorker: true,
-		Identity:              "test-worker-identity",
+		identity:              "test-worker-identity",
 	}
-	worker := NewAggregatedWorker(s.service, nil, taskList, options)
+	worker := NewAggregatedWorker(s.service, taskList, options)
 	worker.RegisterWorkflowWithOptions(
 		longDecisionWorkflowFn,
 		RegisterWorkflowOptions{Name: "multiple-local-activities-workflow-type"},

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -43,7 +43,7 @@ import (
 )
 
 // Assert that structs do indeed implement the interfaces
-var _ Client = (*workflowClient)(nil)
+var _ Client = (*WorkflowClient)(nil)
 var _ DomainClient = (*domainClient)(nil)
 
 const (
@@ -56,8 +56,8 @@ var (
 )
 
 type (
-	// workflowClient is the client for starting a workflow execution.
-	workflowClient struct {
+	// WorkflowClient is the client for starting a workflow execution.
+	WorkflowClient struct {
 		workflowService    workflowservice.WorkflowServiceClient
 		connectionCloser   io.Closer
 		domain             string
@@ -147,7 +147,7 @@ type (
 //     StartWorkflow(options, workflowExecuteFn, arg1, arg2, arg3)
 // The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 // subjected to change in the future.
-func (wc *workflowClient) StartWorkflow(
+func (wc *WorkflowClient) StartWorkflow(
 	ctx context.Context,
 	options StartWorkflowOptions,
 	workflowFunc interface{},
@@ -261,7 +261,7 @@ func (wc *workflowClient) StartWorkflow(
 // The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 // subjected to change in the future.
 // NOTE: the context.Context should have a fairly large timeout, since workflow execution may take a while to be finished
-func (wc *workflowClient) ExecuteWorkflow(ctx context.Context, options StartWorkflowOptions, workflow interface{}, args ...interface{}) (WorkflowRun, error) {
+func (wc *WorkflowClient) ExecuteWorkflow(ctx context.Context, options StartWorkflowOptions, workflow interface{}, args ...interface{}) (WorkflowRun, error) {
 
 	// start the workflow execution
 	var runID string
@@ -298,7 +298,7 @@ func (wc *workflowClient) ExecuteWorkflow(ctx context.Context, options StartWork
 // reaches the end state, such as workflow finished successfully or timeout.
 // The current timeout resolution implementation is in seconds and uses math.Ceil(d.Seconds()) as the duration. But is
 // subjected to change in the future.
-func (wc *workflowClient) GetWorkflow(_ context.Context, workflowID string, runID string) WorkflowRun {
+func (wc *WorkflowClient) GetWorkflow(_ context.Context, workflowID string, runID string) WorkflowRun {
 
 	iterFn := func(fnCtx context.Context, fnRunID string) HistoryEventIterator {
 		return wc.GetWorkflowHistory(fnCtx, workflowID, fnRunID, true, enums.HistoryEventFilterTypeCloseEvent)
@@ -315,7 +315,7 @@ func (wc *workflowClient) GetWorkflow(_ context.Context, workflowID string, runI
 }
 
 // SignalWorkflow signals a workflow in execution.
-func (wc *workflowClient) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
+func (wc *WorkflowClient) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
 	input, err := encodeArg(wc.dataConverter, arg)
 	if err != nil {
 		return err
@@ -343,7 +343,7 @@ func (wc *workflowClient) SignalWorkflow(ctx context.Context, workflowID string,
 
 // SignalWithStartWorkflow sends a signal to a running workflow.
 // If the workflow is not running or not found, it starts the workflow and then sends the signal in transaction.
-func (wc *workflowClient) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{},
+func (wc *WorkflowClient) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{},
 	options StartWorkflowOptions, workflowFunc interface{}, workflowArgs ...interface{}) (*WorkflowExecution, error) {
 
 	signalInput, err := encodeArg(wc.dataConverter, signalArg)
@@ -446,7 +446,7 @@ func (wc *workflowClient) SignalWithStartWorkflow(ctx context.Context, workflowI
 // CancelWorkflow cancels a workflow in execution.  It allows workflow to properly clean up and gracefully close.
 // workflowID is required, other parameters are optional.
 // If runID is omit, it will terminate currently running workflow (if there is one) based on the workflowID.
-func (wc *workflowClient) CancelWorkflow(ctx context.Context, workflowID string, runID string) error {
+func (wc *WorkflowClient) CancelWorkflow(ctx context.Context, workflowID string, runID string) error {
 	request := &workflowservice.RequestCancelWorkflowExecutionRequest{
 		Domain: wc.domain,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -468,7 +468,7 @@ func (wc *workflowClient) CancelWorkflow(ctx context.Context, workflowID string,
 // TerminateWorkflow terminates a workflow execution.
 // workflowID is required, other parameters are optional.
 // If runID is omit, it will terminate currently running workflow (if there is one) based on the workflowID.
-func (wc *workflowClient) TerminateWorkflow(ctx context.Context, workflowID string, runID string, reason string, details []byte) error {
+func (wc *WorkflowClient) TerminateWorkflow(ctx context.Context, workflowID string, runID string, reason string, details []byte) error {
 	request := &workflowservice.TerminateWorkflowExecutionRequest{
 		Domain: wc.domain,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -492,7 +492,7 @@ func (wc *workflowClient) TerminateWorkflow(ctx context.Context, workflowID stri
 }
 
 // GetWorkflowHistory return a channel which contains the history events of a given workflow
-func (wc *workflowClient) GetWorkflowHistory(ctx context.Context, workflowID string, runID string,
+func (wc *WorkflowClient) GetWorkflowHistory(ctx context.Context, workflowID string, runID string,
 	isLongPoll bool, filterType enums.HistoryEventFilterType) HistoryEventIterator {
 
 	domain := wc.domain
@@ -547,7 +547,7 @@ func (wc *workflowClient) GetWorkflowHistory(ctx context.Context, workflowID str
 // should be called when that activity is completed with the actual result and error. If err is nil, activity task
 // completed event will be reported; if err is CanceledError, activity task cancelled event will be reported; otherwise,
 // activity task failed event will be reported.
-func (wc *workflowClient) CompleteActivity(ctx context.Context, taskToken []byte, result interface{}, err error) error {
+func (wc *WorkflowClient) CompleteActivity(ctx context.Context, taskToken []byte, result interface{}, err error) error {
 	if taskToken == nil {
 		return errors.New("invalid task token provided")
 	}
@@ -564,9 +564,9 @@ func (wc *workflowClient) CompleteActivity(ctx context.Context, taskToken []byte
 	return reportActivityComplete(ctx, wc.workflowService, request, wc.metricsScope)
 }
 
-// CompleteActivityById reports activity completed. Similar to CompleteActivity
+// CompleteActivityByID reports activity completed. Similar to CompleteActivity
 // It takes domain name, workflowID, runID, activityID as arguments.
-func (wc *workflowClient) CompleteActivityByID(ctx context.Context, domain, workflowID, runID, activityID string,
+func (wc *WorkflowClient) CompleteActivityByID(ctx context.Context, domain, workflowID, runID, activityID string,
 	result interface{}, err error) error {
 
 	if activityID == "" || workflowID == "" || domain == "" {
@@ -587,7 +587,7 @@ func (wc *workflowClient) CompleteActivityByID(ctx context.Context, domain, work
 }
 
 // RecordActivityHeartbeat records heartbeat for an activity.
-func (wc *workflowClient) RecordActivityHeartbeat(ctx context.Context, taskToken []byte, details ...interface{}) error {
+func (wc *WorkflowClient) RecordActivityHeartbeat(ctx context.Context, taskToken []byte, details ...interface{}) error {
 	data, err := encodeArgs(wc.dataConverter, details)
 	if err != nil {
 		return err
@@ -596,7 +596,7 @@ func (wc *workflowClient) RecordActivityHeartbeat(ctx context.Context, taskToken
 }
 
 // RecordActivityHeartbeatByID records heartbeat for an activity.
-func (wc *workflowClient) RecordActivityHeartbeatByID(ctx context.Context,
+func (wc *WorkflowClient) RecordActivityHeartbeatByID(ctx context.Context,
 	domain, workflowID, runID, activityID string, details ...interface{}) error {
 	data, err := encodeArgs(wc.dataConverter, details)
 	if err != nil {
@@ -610,7 +610,7 @@ func (wc *workflowClient) RecordActivityHeartbeatByID(ctx context.Context,
 //  - BadRequestError
 //  - InternalServiceError
 //  - EntityNotExistError
-func (wc *workflowClient) ListClosedWorkflow(ctx context.Context, request *workflowservice.ListClosedWorkflowExecutionsRequest) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
+func (wc *WorkflowClient) ListClosedWorkflow(ctx context.Context, request *workflowservice.ListClosedWorkflowExecutionsRequest) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
 	if len(request.GetDomain()) == 0 {
 		request.Domain = wc.domain
 	}
@@ -634,7 +634,7 @@ func (wc *workflowClient) ListClosedWorkflow(ctx context.Context, request *workf
 //  - BadRequestError
 //  - InternalServiceError
 //  - EntityNotExistError
-func (wc *workflowClient) ListOpenWorkflow(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+func (wc *WorkflowClient) ListOpenWorkflow(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
 	if len(request.GetDomain()) == 0 {
 		request.Domain = wc.domain
 	}
@@ -654,7 +654,7 @@ func (wc *workflowClient) ListOpenWorkflow(ctx context.Context, request *workflo
 }
 
 // ListWorkflow implementation
-func (wc *workflowClient) ListWorkflow(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*workflowservice.ListWorkflowExecutionsResponse, error) {
+func (wc *WorkflowClient) ListWorkflow(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*workflowservice.ListWorkflowExecutionsResponse, error) {
 	if len(request.GetDomain()) == 0 {
 		request.Domain = wc.domain
 	}
@@ -674,7 +674,7 @@ func (wc *workflowClient) ListWorkflow(ctx context.Context, request *workflowser
 }
 
 // ListArchivedWorkflow implementation
-func (wc *workflowClient) ListArchivedWorkflow(ctx context.Context, request *workflowservice.ListArchivedWorkflowExecutionsRequest) (*workflowservice.ListArchivedWorkflowExecutionsResponse, error) {
+func (wc *WorkflowClient) ListArchivedWorkflow(ctx context.Context, request *workflowservice.ListArchivedWorkflowExecutionsRequest) (*workflowservice.ListArchivedWorkflowExecutionsResponse, error) {
 	if len(request.GetDomain()) == 0 {
 		request.Domain = wc.domain
 	}
@@ -706,7 +706,7 @@ func (wc *workflowClient) ListArchivedWorkflow(ctx context.Context, request *wor
 }
 
 // ScanWorkflow implementation
-func (wc *workflowClient) ScanWorkflow(ctx context.Context, request *workflowservice.ScanWorkflowExecutionsRequest) (*workflowservice.ScanWorkflowExecutionsResponse, error) {
+func (wc *WorkflowClient) ScanWorkflow(ctx context.Context, request *workflowservice.ScanWorkflowExecutionsRequest) (*workflowservice.ScanWorkflowExecutionsResponse, error) {
 	if len(request.GetDomain()) == 0 {
 		request.Domain = wc.domain
 	}
@@ -726,7 +726,7 @@ func (wc *workflowClient) ScanWorkflow(ctx context.Context, request *workflowser
 }
 
 // CountWorkflow implementation
-func (wc *workflowClient) CountWorkflow(ctx context.Context, request *workflowservice.CountWorkflowExecutionsRequest) (*workflowservice.CountWorkflowExecutionsResponse, error) {
+func (wc *WorkflowClient) CountWorkflow(ctx context.Context, request *workflowservice.CountWorkflowExecutionsRequest) (*workflowservice.CountWorkflowExecutionsResponse, error) {
 	if len(request.GetDomain()) == 0 {
 		request.Domain = wc.domain
 	}
@@ -746,7 +746,7 @@ func (wc *workflowClient) CountWorkflow(ctx context.Context, request *workflowse
 }
 
 // GetSearchAttributes implementation
-func (wc *workflowClient) GetSearchAttributes(ctx context.Context) (*workflowservice.GetSearchAttributesResponse, error) {
+func (wc *WorkflowClient) GetSearchAttributes(ctx context.Context) (*workflowservice.GetSearchAttributesResponse, error) {
 	var response *workflowservice.GetSearchAttributesResponse
 	err := backoff.Retry(ctx,
 		func() error {
@@ -767,7 +767,7 @@ func (wc *workflowClient) GetSearchAttributes(ctx context.Context) (*workflowser
 //  - BadRequestError
 //  - InternalServiceError
 //  - EntityNotExistError
-func (wc *workflowClient) DescribeWorkflowExecution(ctx context.Context, workflowID, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+func (wc *WorkflowClient) DescribeWorkflowExecution(ctx context.Context, workflowID, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
 	request := &workflowservice.DescribeWorkflowExecutionRequest{
 		Domain: wc.domain,
 		Execution: &commonproto.WorkflowExecution{
@@ -802,7 +802,7 @@ func (wc *workflowClient) DescribeWorkflowExecution(ctx context.Context, workflo
 //  - InternalServiceError
 //  - EntityNotExistError
 //  - QueryFailError
-func (wc *workflowClient) QueryWorkflow(ctx context.Context, workflowID string, runID string, queryType string, args ...interface{}) (Value, error) {
+func (wc *WorkflowClient) QueryWorkflow(ctx context.Context, workflowID string, runID string, queryType string, args ...interface{}) (Value, error) {
 	queryWorkflowWithOptionsRequest := &QueryWorkflowWithOptionsRequest{
 		WorkflowID: workflowID,
 		RunID:      runID,
@@ -862,7 +862,7 @@ type QueryWorkflowWithOptionsResponse struct {
 //  - InternalServiceError
 //  - EntityNotExistError
 //  - QueryFailError
-func (wc *workflowClient) QueryWorkflowWithOptions(ctx context.Context, request *QueryWorkflowWithOptionsRequest) (*QueryWorkflowWithOptionsResponse, error) {
+func (wc *WorkflowClient) QueryWorkflowWithOptions(ctx context.Context, request *QueryWorkflowWithOptionsRequest) (*QueryWorkflowWithOptionsResponse, error) {
 	var input []byte
 	if len(request.Args) > 0 {
 		var err error
@@ -917,7 +917,7 @@ func (wc *workflowClient) QueryWorkflowWithOptions(ctx context.Context, request 
 //  - BadRequestError
 //  - InternalServiceError
 //  - EntityNotExistError
-func (wc *workflowClient) DescribeTaskList(ctx context.Context, taskList string, taskListType enums.TaskListType) (*workflowservice.DescribeTaskListResponse, error) {
+func (wc *WorkflowClient) DescribeTaskList(ctx context.Context, taskList string, taskListType enums.TaskListType) (*workflowservice.DescribeTaskListResponse, error) {
 	request := &workflowservice.DescribeTaskListRequest{
 		Domain:       wc.domain,
 		TaskList:     &commonproto.TaskList{Name: taskList},
@@ -941,7 +941,7 @@ func (wc *workflowClient) DescribeTaskList(ctx context.Context, taskList string,
 }
 
 // CloseConnection closes underlying gRPC connection.
-func (wc *workflowClient) CloseConnection() error {
+func (wc *WorkflowClient) CloseConnection() error {
 	if wc.connectionCloser == nil {
 		return nil
 	}
@@ -949,7 +949,7 @@ func (wc *workflowClient) CloseConnection() error {
 	return wc.connectionCloser.Close()
 }
 
-func (wc *workflowClient) getWorkflowHeader(ctx context.Context) *commonproto.Header {
+func (wc *WorkflowClient) getWorkflowHeader(ctx context.Context) *commonproto.Header {
 	header := &commonproto.Header{
 		Fields: make(map[string][]byte),
 	}

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -58,7 +58,7 @@ type (
 		suite.Suite
 		mockCtrl              *gomock.Controller
 		workflowServiceClient *workflowservicemock.MockWorkflowServiceClient
-		wfClient              *workflowClient
+		wfClient              *WorkflowClient
 	}
 )
 
@@ -144,7 +144,7 @@ func (s *historyEventIteratorSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
 	s.workflowServiceClient = workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
 
-	s.wfClient = &workflowClient{
+	s.wfClient = &WorkflowClient{
 		workflowService: s.workflowServiceClient,
 		domain:          DefaultDomainName,
 	}
@@ -821,7 +821,7 @@ func (s *workflowClientTestSuite) TestSignalWithStartWorkflow_Error() {
 }
 
 func (s *workflowClientTestSuite) TestStartWorkflow() {
-	client, ok := s.client.(*workflowClient)
+	client, ok := s.client.(*WorkflowClient)
 	s.True(ok)
 	options := StartWorkflowOptions{
 		ID:                              workflowID,
@@ -848,7 +848,7 @@ func (s *workflowClientTestSuite) TestStartWorkflow_WithContext() {
 	s.client = NewServiceClient(s.service, nil, ClientOptions{
 		ContextPropagators: []ContextPropagator{NewStringMapPropagator([]string{testHeader})},
 	})
-	client, ok := s.client.(*workflowClient)
+	client, ok := s.client.(*WorkflowClient)
 	s.True(ok)
 	options := StartWorkflowOptions{
 		ID:                              workflowID,
@@ -878,7 +878,7 @@ func (s *workflowClientTestSuite) TestStartWorkflow_WithContext() {
 func (s *workflowClientTestSuite) TestStartWorkflow_WithDataConverter() {
 	dc := newTestDataConverter()
 	s.client = NewServiceClient(s.service, nil, ClientOptions{DataConverter: dc})
-	client, ok := s.client.(*workflowClient)
+	client, ok := s.client.(*WorkflowClient)
 	s.True(ok)
 	options := StartWorkflowOptions{
 		ID:                              workflowID,

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -293,7 +293,7 @@ func (s *workflowRunSuite) SetupTest() {
 		MetricsScope: metricsScope,
 		Identity:     identity,
 	}
-	s.workflowClient = newServiceClient(s.workflowServiceClient, nil, options)
+	s.workflowClient = NewServiceClient(s.workflowServiceClient, nil, options)
 }
 
 func (s *workflowRunSuite) TearDownTest() {
@@ -760,7 +760,7 @@ func (s *workflowClientTestSuite) SetupSuite() {
 func (s *workflowClientTestSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
 	s.service = workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
-	s.client = newServiceClient(s.service, nil, ClientOptions{})
+	s.client = NewServiceClient(s.service, nil, ClientOptions{})
 }
 
 func (s *workflowClientTestSuite) TearDownTest() {
@@ -845,7 +845,7 @@ func (s *workflowClientTestSuite) TestStartWorkflow() {
 }
 
 func (s *workflowClientTestSuite) TestStartWorkflow_WithContext() {
-	s.client = newServiceClient(s.service, nil, ClientOptions{
+	s.client = NewServiceClient(s.service, nil, ClientOptions{
 		ContextPropagators: []ContextPropagator{NewStringMapPropagator([]string{testHeader})},
 	})
 	client, ok := s.client.(*workflowClient)
@@ -877,7 +877,7 @@ func (s *workflowClientTestSuite) TestStartWorkflow_WithContext() {
 
 func (s *workflowClientTestSuite) TestStartWorkflow_WithDataConverter() {
 	dc := newTestDataConverter()
-	s.client = newServiceClient(s.service, nil, ClientOptions{DataConverter: dc})
+	s.client = NewServiceClient(s.service, nil, ClientOptions{DataConverter: dc})
 	client, ok := s.client.(*workflowClient)
 	s.True(ok)
 	options := StartWorkflowOptions{

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -389,10 +389,6 @@ func (env *testWorkflowEnvironmentImpl) setIdentity(identity string) {
 	env.identity = identity
 }
 
-func (env *testWorkflowEnvironmentImpl) setMetricsScope(metricsScope *metrics.TaggedScope) {
-	env.metricsScope = metricsScope
-}
-
 func (env *testWorkflowEnvironmentImpl) setDataConverter(dataConverter DataConverter) {
 	env.dataConverter = dataConverter
 }

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -124,7 +124,6 @@ type (
 		service            workflowservice.WorkflowServiceClient
 		logger             *zap.Logger
 		metricsScope       *metrics.TaggedScope
-		dataConverter      DataConverter
 		contextPropagators []ContextPropagator
 		identity           string
 		tracer             opentracing.Tracer
@@ -182,6 +181,7 @@ type (
 		testError        error
 		doneChannel      chan struct{}
 		workerOptions    WorkerOptions
+		dataConverter    DataConverter
 		executionTimeout time.Duration
 
 		heartbeatDetails []byte
@@ -217,7 +217,6 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 
 			logger:           s.logger,
 			metricsScope:     metrics.NewTaggedScope(s.scope),
-			dataConverter:    getDefaultDataConverter(),
 			tracer:           opentracing.NoopTracer{},
 			mockClock:        clock.NewMock(),
 			wallClock:        clock.New(),
@@ -250,6 +249,7 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 
 		doneChannel:       make(chan struct{}),
 		workerStopChannel: make(chan struct{}),
+		dataConverter:     getDefaultDataConverter(),
 	}
 
 	// move forward the mock clock to start time.
@@ -1503,7 +1503,7 @@ func (m *mockWrapper) executeMockWithActualArgs(ctx interface{}, inputArgs []int
 }
 
 func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskList string, dataConverter DataConverter) ActivityTaskHandler {
-	augmentWorkerOptions(&env.workerOptions)
+	setWorkerOptionsDefaults(&env.workerOptions)
 	params := workerExecutionParameters{
 		TaskList:           taskList,
 		Identity:           env.identity,

--- a/internal/internal_workflow_testsuite.go
+++ b/internal/internal_workflow_testsuite.go
@@ -303,14 +303,14 @@ func newTestWorkflowEnvironmentImpl(s *WorkflowTestSuite, parentRegistry *regist
 	if env.workerOptions.Logger == nil {
 		env.workerOptions.Logger = env.logger
 	}
-	if env.workerOptions.MetricsScope == nil {
-		env.workerOptions.MetricsScope = env.metricsScope
+	if env.workerOptions.metricsScope == nil {
+		env.workerOptions.metricsScope = env.metricsScope
 	}
-	if env.workerOptions.DataConverter == nil {
-		env.workerOptions.DataConverter = getDefaultDataConverter()
+	if env.workerOptions.dataConverter == nil {
+		env.workerOptions.dataConverter = getDefaultDataConverter()
 	}
-	if len(env.workerOptions.ContextPropagators) == 0 {
-		env.workerOptions.ContextPropagators = env.ctxProps
+	if len(env.workerOptions.contextPropagators) == 0 {
+		env.workerOptions.contextPropagators = env.ctxProps
 	}
 
 	return env
@@ -333,7 +333,7 @@ func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(param
 	childEnv.startedHandler = startedHandler
 	childEnv.testWorkflowEnvironmentShared = env.testWorkflowEnvironmentShared
 	childEnv.workerOptions = env.workerOptions
-	childEnv.workerOptions.DataConverter = params.dataConverter
+	childEnv.workerOptions.dataConverter = params.dataConverter
 	childEnv.registry = env.registry
 
 	if params.workflowID == "" {
@@ -375,17 +375,17 @@ func (env *testWorkflowEnvironmentImpl) newTestWorkflowEnvironmentForChild(param
 }
 
 func (env *testWorkflowEnvironmentImpl) setWorkerOptions(options WorkerOptions) {
-	if len(options.Identity) > 0 {
-		env.workerOptions.Identity = options.Identity
+	if len(options.identity) > 0 {
+		env.workerOptions.identity = options.identity
 	}
 	if options.BackgroundActivityContext != nil {
 		env.workerOptions.BackgroundActivityContext = options.BackgroundActivityContext
 	}
-	if options.MetricsScope != nil {
-		env.workerOptions.MetricsScope = options.MetricsScope
+	if options.metricsScope != nil {
+		env.workerOptions.metricsScope = options.metricsScope
 	}
-	if options.DataConverter != nil {
-		env.workerOptions.DataConverter = options.DataConverter
+	if options.dataConverter != nil {
+		env.workerOptions.dataConverter = options.dataConverter
 	}
 	// Uncomment when resourceID is exposed to user.
 	// if options.SessionResourceID != "" {
@@ -394,8 +394,8 @@ func (env *testWorkflowEnvironmentImpl) setWorkerOptions(options WorkerOptions) 
 	if options.MaxConcurrentSessionExecutionSize != 0 {
 		env.workerOptions.MaxConcurrentSessionExecutionSize = options.MaxConcurrentSessionExecutionSize
 	}
-	if len(options.ContextPropagators) > 0 {
-		env.workerOptions.ContextPropagators = options.ContextPropagators
+	if len(options.contextPropagators) > 0 {
+		env.workerOptions.contextPropagators = options.contextPropagators
 	}
 	env.registry.SetWorkflowInterceptors(options.WorkflowInterceptorChainFactories)
 }
@@ -908,15 +908,15 @@ func (env *testWorkflowEnvironmentImpl) GetLogger() *zap.Logger {
 }
 
 func (env *testWorkflowEnvironmentImpl) GetMetricsScope() tally.Scope {
-	return env.workerOptions.MetricsScope
+	return env.workerOptions.metricsScope
 }
 
 func (env *testWorkflowEnvironmentImpl) GetDataConverter() DataConverter {
-	return env.workerOptions.DataConverter
+	return env.workerOptions.dataConverter
 }
 
 func (env *testWorkflowEnvironmentImpl) GetContextPropagators() []ContextPropagator {
-	return env.workerOptions.ContextPropagators
+	return env.workerOptions.contextPropagators
 }
 
 func (env *testWorkflowEnvironmentImpl) ExecuteActivity(parameters executeActivityParams, callback resultHandler) *activityInfo {
@@ -1082,11 +1082,11 @@ func (env *testWorkflowEnvironmentImpl) ExecuteLocalActivity(params executeLocal
 	task := newLocalActivityTask(params, callback, activityID)
 	taskHandler := localActivityTaskHandler{
 		userContext:        wOptions.BackgroundActivityContext,
-		metricsScope:       metrics.NewTaggedScope(wOptions.MetricsScope),
+		metricsScope:       metrics.NewTaggedScope(wOptions.metricsScope),
 		logger:             wOptions.Logger,
-		dataConverter:      wOptions.DataConverter,
-		tracer:             wOptions.Tracer,
-		contextPropagators: wOptions.ContextPropagators,
+		dataConverter:      wOptions.dataConverter,
+		tracer:             wOptions.tracer,
+		contextPropagators: wOptions.contextPropagators,
 	}
 
 	env.localActivities[activityID] = task
@@ -1502,14 +1502,14 @@ func (env *testWorkflowEnvironmentImpl) newTestActivityTaskHandler(taskList stri
 	wOptions := augmentWorkerOptions(env.workerOptions)
 	params := workerExecutionParameters{
 		TaskList:           taskList,
-		Identity:           wOptions.Identity,
-		MetricsScope:       wOptions.MetricsScope,
+		Identity:           wOptions.identity,
+		MetricsScope:       wOptions.metricsScope,
 		Logger:             wOptions.Logger,
 		UserContext:        wOptions.BackgroundActivityContext,
 		DataConverter:      dataConverter,
 		WorkerStopChannel:  env.workerStopChannel,
-		ContextPropagators: wOptions.ContextPropagators,
-		Tracer:             wOptions.Tracer,
+		ContextPropagators: wOptions.contextPropagators,
+		Tracer:             wOptions.tracer,
 	}
 	ensureRequiredParams(&params)
 	if params.UserContext == nil {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -61,7 +61,7 @@ func (s *WorkflowTestSuiteUnitTest) SetupSuite() {
 	s.header = &commonproto.Header{
 		Fields: map[string][]byte{"test": []byte("test-data")},
 	}
-	s.ctxProps = []ContextPropagator{NewStringMapPropagator([]string{"test"})}
+	s.contextPropagators = []ContextPropagator{NewStringMapPropagator([]string{"test"})}
 }
 
 func TestUnitTestSuite(t *testing.T) {
@@ -120,7 +120,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunction_WithDataConverter(
 	env.RegisterWorkflow(workflowFn)
 	env.RegisterActivity(testActivityHello)
 
-	env.SetWorkerOptions(WorkerOptions{dataConverter: newTestDataConverter()})
+	env.SetDataConverter(newTestDataConverter())
 	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).Return(mockActivity).Twice()
 
 	env.ExecuteWorkflow(workflowFn)
@@ -376,10 +376,6 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithUserContext() {
 }
 
 func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithHeaderContext() {
-	workerOptions := WorkerOptions{
-		contextPropagators: []ContextPropagator{NewStringMapPropagator([]string{testHeader})},
-	}
-
 	// inline activity using value passing through user context.
 	activityWithUserContext := func(ctx context.Context) (string, error) {
 		value := ctx.Value(contextKey(testHeader))
@@ -397,7 +393,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithHeaderContext() {
 
 	env := s.NewTestActivityEnvironment()
 	env.RegisterActivity(activityWithUserContext)
-	env.SetWorkerOptions(workerOptions)
+	env.SetContextPropagators([]ContextPropagator{NewStringMapPropagator([]string{testHeader})})
 	blob, err := env.ExecuteActivity(activityWithUserContext)
 	s.NoError(err)
 	var value string

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -120,7 +120,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunction_WithDataConverter(
 	env.RegisterWorkflow(workflowFn)
 	env.RegisterActivity(testActivityHello)
 
-	env.SetWorkerOptions(WorkerOptions{DataConverter: newTestDataConverter()})
+	env.SetWorkerOptions(WorkerOptions{dataConverter: newTestDataConverter()})
 	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).Return(mockActivity).Twice()
 
 	env.ExecuteWorkflow(workflowFn)
@@ -377,7 +377,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithUserContext() {
 
 func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithHeaderContext() {
 	workerOptions := WorkerOptions{
-		ContextPropagators: []ContextPropagator{NewStringMapPropagator([]string{testHeader})},
+		contextPropagators: []ContextPropagator{NewStringMapPropagator([]string{testHeader})},
 	}
 
 	// inline activity using value passing through user context.

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -188,7 +188,7 @@ func NewWorker(
 	taskList string,
 	options WorkerOptions,
 ) *AggregatedWorker {
-	workflowClient, ok := client.(*workflowClient)
+	workflowClient, ok := client.(*WorkflowClient)
 	if !ok {
 		panic("Client must be created with client.NewClient()")
 	}

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -188,6 +188,7 @@ func NewWorker(
 	taskList string,
 	options WorkerOptions,
 ) *AggregatedWorker {
+	// TODO: refactor and remove this downcast: https://github.com/temporalio/temporal-go-sdk/issues/70
 	workflowClient, ok := client.(*WorkflowClient)
 	if !ok {
 		panic("Client must be created with client.NewClient()")

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -24,8 +24,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
-	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 
@@ -150,13 +148,6 @@ type (
 		// Optional: Specifies factories used to instantiate workflow interceptor chain
 		// The chain is instantiated per each replay of a workflow execution
 		WorkflowInterceptorChainFactories []WorkflowInterceptorFactory
-
-		domainName         string
-		metricsScope       tally.Scope
-		identity           string
-		dataConverter      DataConverter
-		tracer             opentracing.Tracer
-		contextPropagators []ContextPropagator
 	}
 )
 
@@ -201,13 +192,5 @@ func NewWorker(
 	if !ok {
 		panic("Client must be created with client.NewClient()")
 	}
-
-	options.domainName = workflowClient.domain
-	options.metricsScope = workflowClient.metricsScope
-	options.identity = workflowClient.identity
-	options.dataConverter = workflowClient.dataConverter
-	options.tracer = workflowClient.tracer
-	options.contextPropagators = workflowClient.contextPropagators
-
-	return NewAggregatedWorker(workflowClient.workflowService, taskList, options)
+	return NewAggregatedWorker(workflowClient, taskList, options)
 }

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/mock"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
@@ -176,13 +177,33 @@ func (t *TestActivityEnvironment) ExecuteLocalActivity(activityFn interface{}, a
 }
 
 // SetWorkerOptions sets the WorkerOptions that will be use by TestActivityEnvironment. TestActivityEnvironment will
-// use options of Identity, MetricsScope and BackgroundActivityContext on the WorkerOptions. Other options are ignored.
+// use options of BackgroundActivityContext, MaxConcurrentSessionExecutionSize, and WorkflowInterceptorChainFactories on the WorkerOptions.
+// Other options are ignored.
 // Note: WorkerOptions is defined in internal package, use public type worker.Options instead.
 func (t *TestActivityEnvironment) SetWorkerOptions(options WorkerOptions) *TestActivityEnvironment {
 	t.impl.setWorkerOptions(options)
 	return t
 }
 
+// SetDataConverter sets data converter.
+func (t *TestActivityEnvironment) SetDataConverter(dataConverter DataConverter) *TestActivityEnvironment {
+	t.impl.setDataConverter(dataConverter)
+	return t
+}
+
+// SetIdentity sets identity.
+func (t *TestActivityEnvironment) SetIdentity(identity string) *TestActivityEnvironment {
+	t.impl.setIdentity(identity)
+	return t
+}
+
+// SetTracer sets tracer.
+func (t *TestActivityEnvironment) SetTracer(tracer opentracing.Tracer) *TestActivityEnvironment {
+	t.impl.setTracer(tracer)
+	return t
+}
+
+// SetContextPropagators sets context propagators.
 func (t *TestActivityEnvironment) SetContextPropagators(contextPropagators []ContextPropagator) *TestActivityEnvironment {
 	t.impl.setContextPropagators(contextPropagators)
 	return t
@@ -446,16 +467,30 @@ func (t *TestWorkflowEnvironment) Now() time.Time {
 	return t.impl.Now()
 }
 
-// SetWorkerOptions sets the WorkerOptions for TestWorkflowEnvironment. TestWorkflowEnvironment will use options set by
-// use options of Identity, MetricsScope and BackgroundActivityContext on the WorkerOptions. Other options are ignored.
+// SetWorkerOptions sets the WorkerOptions that will be use by TestActivityEnvironment. TestActivityEnvironment will
+// use options of BackgroundActivityContext, MaxConcurrentSessionExecutionSize, and WorkflowInterceptorChainFactories on the WorkerOptions.
+// Other options are ignored.
 // Note: WorkerOptions is defined in internal package, use public type worker.Options instead.
 func (t *TestWorkflowEnvironment) SetWorkerOptions(options WorkerOptions) *TestWorkflowEnvironment {
 	t.impl.setWorkerOptions(options)
 	return t
 }
 
+// SetDataConverter sets data converter.
 func (t *TestWorkflowEnvironment) SetDataConverter(dataConverter DataConverter) *TestWorkflowEnvironment {
 	t.impl.setDataConverter(dataConverter)
+	return t
+}
+
+// SetIdentity sets identity.
+func (t *TestWorkflowEnvironment) SetIdentity(identity string) *TestWorkflowEnvironment {
+	t.impl.setIdentity(identity)
+	return t
+}
+
+// SetTracer sets tracer.
+func (t *TestWorkflowEnvironment) SetTracer(tracer opentracing.Tracer) *TestWorkflowEnvironment {
+	t.impl.setTracer(tracer)
 	return t
 }
 

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -46,10 +46,10 @@ type (
 
 	// WorkflowTestSuite is the test suite to run unit tests for workflow/activity.
 	WorkflowTestSuite struct {
-		logger   *zap.Logger
-		scope    tally.Scope
-		ctxProps []ContextPropagator
-		header   *commonproto.Header
+		logger             *zap.Logger
+		scope              tally.Scope
+		contextPropagators []ContextPropagator
+		header             *commonproto.Header
 	}
 
 	// TestWorkflowEnvironment is the environment that you use to test workflow
@@ -144,7 +144,7 @@ func (s *WorkflowTestSuite) SetMetricsScope(scope tally.Scope) {
 // SetContextPropagators sets the context propagators for this WorkflowTestSuite. If you don't set context propagators,
 // test suite will not use context propagators
 func (s *WorkflowTestSuite) SetContextPropagators(ctxProps []ContextPropagator) {
-	s.ctxProps = ctxProps
+	s.contextPropagators = ctxProps
 }
 
 // SetHeader sets the headers for this WorkflowTestSuite. If you don't set header, test suite will not pass headers to
@@ -180,6 +180,11 @@ func (t *TestActivityEnvironment) ExecuteLocalActivity(activityFn interface{}, a
 // Note: WorkerOptions is defined in internal package, use public type worker.Options instead.
 func (t *TestActivityEnvironment) SetWorkerOptions(options WorkerOptions) *TestActivityEnvironment {
 	t.impl.setWorkerOptions(options)
+	return t
+}
+
+func (t *TestActivityEnvironment) SetContextPropagators(contextPropagators []ContextPropagator) *TestActivityEnvironment {
+	t.impl.setContextPropagators(contextPropagators)
 	return t
 }
 
@@ -446,6 +451,11 @@ func (t *TestWorkflowEnvironment) Now() time.Time {
 // Note: WorkerOptions is defined in internal package, use public type worker.Options instead.
 func (t *TestWorkflowEnvironment) SetWorkerOptions(options WorkerOptions) *TestWorkflowEnvironment {
 	t.impl.setWorkerOptions(options)
+	return t
+}
+
+func (t *TestWorkflowEnvironment) SetDataConverter(dataConverter DataConverter) *TestWorkflowEnvironment {
+	t.impl.setDataConverter(dataConverter)
 	return t
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -138,7 +138,7 @@ func (ts *IntegrationTestSuite) SetupTest() {
 	ts.NoError(err)
 	ts.tracer = newtracingInterceptorFactory()
 	options := worker.Options{
-		DomainName:                        domainName,
+		domainName:                        domainName,
 		DisableStickyExecution:            ts.config.IsStickyOff,
 		Logger:                            logger,
 		WorkflowInterceptorChainFactories: []interceptors.WorkflowInterceptorFactory{ts.tracer},

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -49,7 +49,7 @@ type IntegrationTestSuite struct {
 	*require.Assertions
 	suite.Suite
 	config       Config
-	libClient    client.Client
+	client       client.Client
 	activities   *Activities
 	workflows    *Workflows
 	worker       worker.Worker
@@ -96,14 +96,14 @@ func (ts *IntegrationTestSuite) SetupSuite() {
 	ts.workflows = &Workflows{}
 	ts.NoError(waitForTCP(time.Minute, ts.config.ServiceAddr))
 	var err error
-	ts.libClient, err = client.NewClient(client.Options{HostPort: ts.config.ServiceAddr, DomainName: domainName})
+	ts.client, err = client.NewClient(client.Options{HostPort: ts.config.ServiceAddr, DomainName: domainName})
 	ts.NoError(err)
 	ts.registerDomain()
 }
 
 func (ts *IntegrationTestSuite) TearDownSuite() {
 	ts.Assertions = require.New(ts.T())
-	err := ts.libClient.CloseConnection()
+	err := ts.client.CloseConnection()
 	ts.NoError(err)
 
 	// allow the pollers to shut down, and ensure there are no goroutine leaks.
@@ -138,14 +138,11 @@ func (ts *IntegrationTestSuite) SetupTest() {
 	ts.NoError(err)
 	ts.tracer = newtracingInterceptorFactory()
 	options := worker.Options{
-		domainName:                        domainName,
 		DisableStickyExecution:            ts.config.IsStickyOff,
 		Logger:                            logger,
 		WorkflowInterceptorChainFactories: []interceptors.WorkflowInterceptorFactory{ts.tracer},
-		HostPort:                          ts.config.ServiceAddr,
 	}
-	ts.worker, err = worker.New(ts.taskListName, options)
-	ts.NoError(err)
+	ts.worker = worker.New(ts.client, ts.taskListName, options)
 	ts.registerWorkflowsAndActivities(ts.worker)
 	ts.Nil(ts.worker.Start())
 }
@@ -228,11 +225,11 @@ func (ts *IntegrationTestSuite) TestContinueAsNewCarryOver() {
 func (ts *IntegrationTestSuite) TestCancellation() {
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
-	run, err := ts.libClient.ExecuteWorkflow(ctx,
+	run, err := ts.client.ExecuteWorkflow(ctx,
 		ts.startWorkflowOptions("test-cancellation"), ts.workflows.Basic)
 	ts.NoError(err)
 	ts.NotNil(run)
-	ts.Nil(ts.libClient.CancelWorkflow(ctx, "test-cancellation", run.GetRunID()))
+	ts.Nil(ts.client.CancelWorkflow(ctx, "test-cancellation", run.GetRunID()))
 	err = run.Get(ctx, nil)
 	ts.Error(err)
 	_, ok := err.(*temporal.CanceledError)
@@ -242,10 +239,10 @@ func (ts *IntegrationTestSuite) TestCancellation() {
 func (ts *IntegrationTestSuite) TestStackTraceQuery() {
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
-	run, err := ts.libClient.ExecuteWorkflow(ctx,
+	run, err := ts.client.ExecuteWorkflow(ctx,
 		ts.startWorkflowOptions("test-stack-trace-query"), ts.workflows.Basic)
 	ts.NoError(err)
-	value, err := ts.libClient.QueryWorkflow(ctx, "test-stack-trace-query", run.GetRunID(), "__stack_trace")
+	value, err := ts.client.QueryWorkflow(ctx, "test-stack-trace-query", run.GetRunID(), "__stack_trace")
 	ts.NoError(err)
 	ts.NotNil(value)
 	var trace string
@@ -260,7 +257,7 @@ func (ts *IntegrationTestSuite) TestConsistentQuery() {
 	// to ensure that consistent query must wait in order to satisfy consistency
 	wfOpts := ts.startWorkflowOptions("test-consistent-query")
 	wfOpts.DecisionTaskStartToCloseTimeout = 5 * time.Second
-	run, err := ts.libClient.ExecuteWorkflow(ctx, wfOpts, ts.workflows.ConsistentQueryWorkflow, 3*time.Second)
+	run, err := ts.client.ExecuteWorkflow(ctx, wfOpts, ts.workflows.ConsistentQueryWorkflow, 3*time.Second)
 	ts.Nil(err)
 	// Wait for a second to ensure that first decision task gets started and completed before we send signal.
 	// Query cannot be run until first decision task has been completed.
@@ -268,10 +265,10 @@ func (ts *IntegrationTestSuite) TestConsistentQuery() {
 	// decision task. So query will be blocked waiting for signal to complete, this is not what we want because it
 	// will not exercise the consistent query code path.
 	<-time.After(time.Second)
-	err = ts.libClient.SignalWorkflow(ctx, "test-consistent-query", run.GetRunID(), consistentQuerySignalCh, "signal-input")
+	err = ts.client.SignalWorkflow(ctx, "test-consistent-query", run.GetRunID(), consistentQuerySignalCh, "signal-input")
 	ts.NoError(err)
 
-	value, err := ts.libClient.QueryWorkflowWithOptions(ctx, &client.QueryWorkflowWithOptionsRequest{
+	value, err := ts.client.QueryWorkflowWithOptions(ctx, &client.QueryWorkflowWithOptionsRequest{
 		WorkflowID:            "test-consistent-query",
 		RunID:                 run.GetRunID(),
 		QueryType:             "consistent_query",
@@ -376,7 +373,7 @@ func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyTerminate() {
 	err := ts.executeWorkflow("test-childwf-parent-close-policy", ts.workflows.ChildWorkflowSuccessWithParentClosePolicyTerminate, &childWorkflowID)
 	ts.NoError(err)
 	for {
-		resp, err := ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
+		resp, err := ts.client.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
 		ts.NoError(err)
 		info := resp.WorkflowExecutionInfo
 		if info.GetCloseTime().GetValue() > 0 {
@@ -393,7 +390,7 @@ func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyAbandon() {
 	ts.NoError(err)
 
 	for {
-		resp, err := ts.libClient.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
+		resp, err := ts.client.DescribeWorkflowExecution(context.Background(), childWorkflowID, "")
 		ts.NoError(err)
 		info := resp.WorkflowExecutionInfo
 		if info.GetCloseTime().GetValue() > 0 {
@@ -423,10 +420,10 @@ func (ts *IntegrationTestSuite) TestActivityCancelRepro() {
 func (ts *IntegrationTestSuite) TestLargeQueryResultError() {
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
-	run, err := ts.libClient.ExecuteWorkflow(ctx,
+	run, err := ts.client.ExecuteWorkflow(ctx,
 		ts.startWorkflowOptions("test-large-query-error"), ts.workflows.LargeQueryResultWorkflow)
 	ts.Nil(err)
-	value, err := ts.libClient.QueryWorkflow(ctx, "test-large-query-error", run.GetRunID(), "large_query")
+	value, err := ts.client.QueryWorkflow(ctx, "test-large-query-error", run.GetRunID(), "large_query")
 	ts.Error(err)
 
 	ts.IsType(&serviceerror.QueryFailed{}, err)
@@ -477,13 +474,13 @@ func (ts *IntegrationTestSuite) executeWorkflowWithOption(
 	options client.StartWorkflowOptions, wfFunc interface{}, retValPtr interface{}, args ...interface{}) error {
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
-	run, err := ts.libClient.ExecuteWorkflow(ctx, options, wfFunc, args...)
+	run, err := ts.client.ExecuteWorkflow(ctx, options, wfFunc, args...)
 	if err != nil {
 		return err
 	}
 	err = run.Get(ctx, retValPtr)
 	if ts.config.Debug {
-		iter := ts.libClient.GetWorkflowHistory(ctx, options.ID, run.GetRunID(), false, enums.HistoryEventFilterTypeAllEvent)
+		iter := ts.client.GetWorkflowHistory(ctx, options.ID, run.GetRunID(), false, enums.HistoryEventFilterTypeAllEvent)
 		for iter.HasNext() {
 			event, err1 := iter.Next()
 			if err1 != nil {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/zap"
 
 	"go.temporal.io/temporal/activity"
+	"go.temporal.io/temporal/client"
 	"go.temporal.io/temporal/internal"
 	"go.temporal.io/temporal/workflow"
 )
@@ -187,10 +188,11 @@ const (
 //               hosted by a single worker process
 //    options  - configure any worker specific options like logger, metrics, identity
 func New(
+	client client.Client,
 	taskList string,
 	options Options,
-) (Worker, error) {
-	return internal.NewWorker(taskList, options)
+) Worker {
+	return internal.NewWorker(client, taskList, options)
 }
 
 // NewWorkflowReplayer creates a WorkflowReplayer instance.


### PR DESCRIPTION
`worker.NewWorker` now depends on `client.Client` interface. It doesn't create/close own gRPC connection but uses client connection instead.

I had to make few short term shortcuts which I described below.