### PR TITLE
updating temporalio/auto-setup image name in docker-compose-local.yml

### DIFF
--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -23,7 +23,7 @@ services:
           - statsd
 
   temporal:
-    image: temporalio/temporal:master-auto-setup
+    image: temporalio/auto-setup:latest
     ports:
       - "7233:7233"
       - "7234:7234"


### PR DESCRIPTION
bringing docker-compose-local file up to date with the current image naming convention.  