### PR TITLE
Added ability to call method activities by function pointer

### DIFF
--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -1470,7 +1470,16 @@ func getFunctionName(i interface{}) string {
 	}
 	fullName := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 	elements := strings.Split(fullName, ".")
-	return elements[len(elements)-1]
+	shortName := elements[len(elements)-1]
+	// This allows to call activities by method pointer
+	// Compiler adds -fm suffix to a function name which has a receiver
+	// Note that this works even if struct pointer used to get the function is nil
+	// It is possible because nil receivers are allowed.
+	// For example:
+	// var a *Activities
+	// ExecuteActivity(ctx, a.Foo)
+	// will call this function which is going to return "Foo"
+	return strings.TrimSuffix(shortName, "-fm")
 }
 
 func getActivityFunctionName(r *registry, i interface{}) string {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2091,7 +2091,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_Channel() {
 				}
 
 				// continue as new
-				return NewContinueAsNewError(ctx, "this-workflow-fn")
+				return NewContinueAsNewError(ctx, "this-workflow")
 			}
 
 			for i := range fanoutChs {

--- a/test/fixtures/activity.cancel.sm.repro.json
+++ b/test/fixtures/activity.cancel.sm.repro.json
@@ -7,7 +7,7 @@
       "version": -24,
       "workflowExecutionStartedEventAttributes": {
         "workflowType": {
-          "name": "ActivityCancelRepro-fm"
+          "name": "ActivityCancelRepro"
         },
         "taskList": {
           "name": "tl-1"

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -166,7 +166,7 @@ func (ts *IntegrationTestSuite) TestBasic() {
 	// See https://grokbase.com/p/gg/golang-nuts/153jjj8dgg/go-nuts-fm-suffix-in-function-name-what-does-it-mean
 	// for explanation of -fm postfix.
 	ts.Equal([]string{"ExecuteWorkflow begin", "ExecuteActivity", "ExecuteActivity", "ExecuteWorkflow end"},
-		ts.tracer.GetTrace("Basic-fm"))
+		ts.tracer.GetTrace("Basic"))
 }
 
 func (ts *IntegrationTestSuite) TestActivityRetryOnError() {
@@ -372,7 +372,7 @@ func (ts *IntegrationTestSuite) TestChildWFWithMemoAndSearchAttributes() {
 	ts.NoError(err)
 	ts.EqualValues([]string{"getMemoAndSearchAttr"}, ts.activities.invoked())
 	ts.Equal("memoVal, searchAttrVal", result)
-	ts.Equal([]string{"ExecuteWorkflow begin", "ExecuteChildWorkflow", "ExecuteWorkflow end"}, ts.tracer.GetTrace("ChildWorkflowSuccess-fm"))
+	ts.Equal([]string{"ExecuteWorkflow begin", "ExecuteChildWorkflow", "ExecuteWorkflow end"}, ts.tracer.GetTrace("ChildWorkflowSuccess"))
 }
 
 func (ts *IntegrationTestSuite) TestChildWFWithParentClosePolicyTerminate() {

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -443,8 +443,10 @@ func (w *Workflows) RetryTimeoutStableErrorWorkflow(ctx workflow.Context) ([]str
 		},
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
-
-	err := workflow.ExecuteActivity(ctx, "RetryTimeoutStableErrorActivity").Get(ctx, nil)
+	// Test calling activity by method pointer
+	// As Go allows nil receiver pointers it works fine
+	var a *Activities
+	err := workflow.ExecuteActivity(ctx, a.RetryTimeoutStableErrorActivity).Get(ctx, nil)
 
 	cerr, ok := err.(*temporal.CustomError)
 	if !ok {


### PR DESCRIPTION
Makes possible the following trick:

```
type Activities struct {
...
}

func (a *Activities) RetryTimeoutStableErrorActivity() error {
...
}

```
And inside the workflow:

```
	var a *Activities
	err := workflow.ExecuteActivity(ctx, a.RetryTimeoutStableErrorActivity).Get(ctx, nil)

```
This is possible as Go allows nil function receivers.