### PR TITLE
Renamed NonDeterministicWorkflowPolicy to WorkflowPanicPolicy

### DIFF
--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -122,19 +122,19 @@ type (
 
 	// workflowTaskHandlerImpl is the implementation of WorkflowTaskHandler
 	workflowTaskHandlerImpl struct {
-		namespace                      string
-		metricsScope                   *metrics.TaggedScope
-		ppMgr                          pressurePointMgr
-		logger                         *zap.Logger
-		identity                       string
-		enableLoggingInReplay          bool
-		disableStickyExecution         bool
-		registry                       *registry
-		laTunnel                       *localActivityTunnel
-		nonDeterministicWorkflowPolicy NonDeterministicWorkflowPolicy
-		dataConverter                  DataConverter
-		contextPropagators             []ContextPropagator
-		tracer                         opentracing.Tracer
+		namespace              string
+		metricsScope           *metrics.TaggedScope
+		ppMgr                  pressurePointMgr
+		logger                 *zap.Logger
+		identity               string
+		enableLoggingInReplay  bool
+		disableStickyExecution bool
+		registry               *registry
+		laTunnel               *localActivityTunnel
+		workflowPanicPolicy    WorkflowPanicPolicy
+		dataConverter          DataConverter
+		contextPropagators     []ContextPropagator
+		tracer                 opentracing.Tracer
 	}
 
 	activityProvider func(name string) activity
@@ -379,18 +379,18 @@ func isPreloadMarkerEvent(event *eventpb.HistoryEvent) bool {
 func newWorkflowTaskHandler(params workerExecutionParameters, ppMgr pressurePointMgr, registry *registry) WorkflowTaskHandler {
 	ensureRequiredParams(&params)
 	return &workflowTaskHandlerImpl{
-		namespace:                      params.Namespace,
-		logger:                         params.Logger,
-		ppMgr:                          ppMgr,
-		metricsScope:                   metrics.NewTaggedScope(params.MetricsScope),
-		identity:                       params.Identity,
-		enableLoggingInReplay:          params.EnableLoggingInReplay,
-		disableStickyExecution:         params.DisableStickyExecution,
-		registry:                       registry,
-		nonDeterministicWorkflowPolicy: params.NonDeterministicWorkflowPolicy,
-		dataConverter:                  params.DataConverter,
-		contextPropagators:             params.ContextPropagators,
-		tracer:                         params.Tracer,
+		namespace:              params.Namespace,
+		logger:                 params.Logger,
+		ppMgr:                  ppMgr,
+		metricsScope:           metrics.NewTaggedScope(params.MetricsScope),
+		identity:               params.Identity,
+		enableLoggingInReplay:  params.EnableLoggingInReplay,
+		disableStickyExecution: params.DisableStickyExecution,
+		registry:               registry,
+		workflowPanicPolicy:    params.WorkflowPanicPolicy,
+		dataConverter:          params.DataConverter,
+		contextPropagators:     params.ContextPropagators,
+		tracer:                 params.Tracer,
 	}
 }
 
@@ -928,11 +928,11 @@ ProcessEvents:
 			zap.String(tagRunID, task.WorkflowExecution.GetRunId()),
 			zap.Error(nonDeterministicErr))
 
-		switch w.wth.nonDeterministicWorkflowPolicy {
-		case NonDeterministicWorkflowPolicyFailWorkflow:
+		switch w.wth.workflowPanicPolicy {
+		case FailWorkflow:
 			// complete workflow with custom error will fail the workflow
-			eventHandler.Complete(nil, NewCustomError("NonDeterministicWorkflowPolicyFailWorkflow", nonDeterministicErr.Error()))
-		case NonDeterministicWorkflowPolicyBlockWorkflow:
+			eventHandler.Complete(nil, NewCustomError("FailWorkflow", nonDeterministicErr.Error()))
+		case BlockWorkflow:
 			// return error here will be convert to DecisionTaskFailed for the first time, and ignored for subsequent
 			// attempts which will cause DecisionTaskTimeout and server will retry forever until issue got fixed or
 			// workflow timeout.

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -559,11 +559,11 @@ func (t *TaskHandlersTestSuite) TestCacheEvictionWhenErrorOccurs() {
 		}),
 	}
 	params := workerExecutionParameters{
-		Namespace:                      testNamespace,
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		Namespace:           testNamespace,
+		TaskList:            taskList,
+		Identity:            "test-id-1",
+		Logger:              zap.NewNop(),
+		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
 	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
@@ -594,11 +594,11 @@ func (t *TaskHandlersTestSuite) TestWithMissingHistoryEvents() {
 		createTestEventDecisionTaskStarted(7),
 	}
 	params := workerExecutionParameters{
-		Namespace:                      testNamespace,
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		Namespace:           testNamespace,
+		TaskList:            taskList,
+		Identity:            "test-id-1",
+		Logger:              zap.NewNop(),
+		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
 	for _, startEventID := range []int64{0, 3} {
@@ -635,11 +635,11 @@ func (t *TaskHandlersTestSuite) TestWithTruncatedHistory() {
 		}),
 	}
 	params := workerExecutionParameters{
-		Namespace:                      testNamespace,
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		Namespace:           testNamespace,
+		TaskList:            taskList,
+		Identity:            "test-id-1",
+		Logger:              zap.NewNop(),
+		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
 	testCases := []struct {
@@ -755,12 +755,12 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	task := createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
 	stopC := make(chan struct{})
 	params := workerExecutionParameters{
-		Namespace:                      testNamespace,
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
-		WorkerStopChannel:              stopC,
+		Namespace:           testNamespace,
+		TaskList:            taskList,
+		Identity:            "test-id-1",
+		Logger:              zap.NewNop(),
+		WorkflowPanicPolicy: BlockWorkflow,
+		WorkerStopChannel:   stopC,
 	}
 
 	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
@@ -783,7 +783,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 
 	// now, create a new task handler with fail nondeterministic workflow policy
 	// and verify that it handles the mismatching history correctly.
-	params.NonDeterministicWorkflowPolicy = NonDeterministicWorkflowPolicyFailWorkflow
+	params.WorkflowPanicPolicy = FailWorkflow
 	failOnNondeterminismTaskHandler := newWorkflowTaskHandler(params, nil, t.registry)
 	task = createWorkflowTask(testEvents, 3, "HelloWorld_Workflow")
 	request, err = failOnNondeterminismTaskHandler.ProcessWorkflowTask(&workflowTask{task: task}, nil)
@@ -799,7 +799,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_NondeterministicDetection() {
 	t.True(len(response.Decisions) > 0)
 	closeDecision := response.Decisions[len(response.Decisions)-1]
 	t.Equal(closeDecision.DecisionType, decisionpb.DecisionType_FailWorkflowExecution)
-	t.Contains(closeDecision.GetFailWorkflowExecutionDecisionAttributes().Reason, "NonDeterministicWorkflowPolicyFailWorkflow")
+	t.Contains(closeDecision.GetFailWorkflowExecutionDecisionAttributes().Reason, "FailWorkflow")
 
 	// now with different package name to activity type
 	testEvents[4].GetActivityTaskScheduledEventAttributes().ActivityType.Name = "new-package.Greeter_Activity"
@@ -818,11 +818,11 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowReturnsPanicError() {
 	}
 	task := createWorkflowTask(testEvents, 3, "ReturnPanicWorkflow")
 	params := workerExecutionParameters{
-		Namespace:                      testNamespace,
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		Namespace:           testNamespace,
+		TaskList:            taskList,
+		Identity:            "test-id-1",
+		Logger:              zap.NewNop(),
+		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
 	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
@@ -847,11 +847,11 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowPanics() {
 	}
 	task := createWorkflowTask(testEvents, 3, "PanicWorkflow")
 	params := workerExecutionParameters{
-		Namespace:                      testNamespace,
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		Namespace:           testNamespace,
+		TaskList:            taskList,
+		Identity:            "test-id-1",
+		Logger:              zap.NewNop(),
+		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
 	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
@@ -900,11 +900,11 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 	}
 	task := createWorkflowTask(testEvents, 3, workflowType)
 	params := workerExecutionParameters{
-		Namespace:                      testNamespace,
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		Namespace:           testNamespace,
+		TaskList:            taskList,
+		Identity:            "test-id-1",
+		Logger:              zap.NewNop(),
+		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
 	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)
@@ -933,11 +933,11 @@ func (t *TaskHandlersTestSuite) TestGetWorkflowInfo() {
 func (t *TaskHandlersTestSuite) TestConsistentQuery_InvalidQueryTask() {
 	taskList := "taskList"
 	params := workerExecutionParameters{
-		Namespace:                      testNamespace,
-		TaskList:                       taskList,
-		Identity:                       "test-id-1",
-		Logger:                         zap.NewNop(),
-		NonDeterministicWorkflowPolicy: NonDeterministicWorkflowPolicyBlockWorkflow,
+		Namespace:           testNamespace,
+		TaskList:            taskList,
+		Identity:            "test-id-1",
+		Logger:              zap.NewNop(),
+		WorkflowPanicPolicy: BlockWorkflow,
 	}
 
 	taskHandler := newWorkflowTaskHandler(params, nil, t.registry)

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -181,9 +181,11 @@ type (
 
 		StickyScheduleToStartTimeout time.Duration
 
-		// NonDeterministicWorkflowPolicy is used for configuring how client's decision task handler deals with
-		// mismatched history events (presumably arising from non-deterministic workflow definitions).
-		NonDeterministicWorkflowPolicy NonDeterministicWorkflowPolicy
+		// WorkflowPanicPolicy is used for configuring how client's decision task handler deals with workflow
+		// code panicking which includes non backwards compatible changes to the workflow code without appropriate
+		// versioning (see workflow.GetVersion).
+		// The default behavior is to block workflow execution until the problem is fixed.
+		WorkflowPanicPolicy WorkflowPanicPolicy
 
 		DataConverter DataConverter
 
@@ -1351,7 +1353,7 @@ func NewAggregatedWorker(client *WorkflowClient, taskList string, options Worker
 		DisableStickyExecution:               options.DisableStickyExecution,
 		StickyScheduleToStartTimeout:         options.StickyScheduleToStartTimeout,
 		TaskListActivitiesPerSecond:          options.TaskListActivitiesPerSecond,
-		NonDeterministicWorkflowPolicy:       options.NonDeterministicWorkflowPolicy,
+		WorkflowPanicPolicy:                  options.NonDeterministicWorkflowPolicy,
 		DataConverter:                        client.dataConverter,
 		WorkerStopTimeout:                    options.WorkerStopTimeout,
 		ContextPropagators:                   client.contextPropagators,

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1298,7 +1298,7 @@ func assertWorkerExecutionParamsEqual(t *testing.T, paramsA workerExecutionParam
 	require.Equal(t, paramsA.StickyScheduleToStartTimeout, paramsB.StickyScheduleToStartTimeout)
 	require.Equal(t, paramsA.MaxConcurrentDecisionPollers, paramsB.MaxConcurrentDecisionPollers)
 	require.Equal(t, paramsA.MaxConcurrentActivityPollers, paramsB.MaxConcurrentActivityPollers)
-	require.Equal(t, paramsA.NonDeterministicWorkflowPolicy, paramsB.NonDeterministicWorkflowPolicy)
+	require.Equal(t, paramsA.WorkflowPanicPolicy, paramsB.WorkflowPanicPolicy)
 	require.Equal(t, paramsA.EnableLoggingInReplay, paramsB.EnableLoggingInReplay)
 	require.Equal(t, paramsA.DisableStickyExecution, paramsB.DisableStickyExecution)
 }

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1752,15 +1752,15 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListene
 	})
 
 	env.ExecuteWorkflow(workflowFn)
-	env.AssertExpectations(s.T())
-	s.Equal(2, startedCount)
-	s.Equal(1, completedCount)
-	s.Equal(1, canceledCount)
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())
 	var result string
 	err := env.GetWorkflowResult(&result)
 	s.NoError(err)
+	env.AssertExpectations(s.T())
+	s.Equal(2, startedCount)
+	s.Equal(1, completedCount)
+	s.Equal(1, canceledCount)
 	s.Equal("hello mock", result)
 	s.True(localActivityFnCancelled.Load())
 }

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1695,6 +1695,8 @@ func (s *WorkflowTestSuiteUnitTest) Test_LocalActivity() {
 
 func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListeners() {
 	var localActivityFnCancelled atomic.Bool
+	var startedCount, completedCount, canceledCount atomic.Int32
+
 	localActivityFn := func(ctx context.Context, name string) (string, error) {
 		return "hello " + name, nil
 	}
@@ -1712,14 +1714,12 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListene
 		ctx2, cancel := WithCancel(ctx)
 		f2 := ExecuteLocalActivity(ctx2, cancelledLocalActivityFn)
 
-		NewSelector(ctx).
-			AddFuture(f, func(f Future) {
-				cancel()
-			}).
-			AddFuture(f2, func(f Future) {
-
-			}).
-			Select(ctx)
+		f.Get(ctx, nil)
+		// Hack to avoid race condition. Never do anything similar in real production code
+		for startedCount.Load() < 2 {
+			time.Sleep(100 * time.Millisecond)
+		}
+		cancel()
 
 		err2 := f2.Get(ctx, nil)
 		if _, ok := err2.(*CanceledError); !ok {
@@ -1733,9 +1733,8 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListene
 	env := s.NewTestWorkflowEnvironment()
 	env.RegisterWorkflow(workflowFn)
 	env.OnActivity(localActivityFn, mock.Anything, "local_activity").Return("hello mock", nil).Once()
-	var startedCount, completedCount, canceledCount int
 	env.SetOnLocalActivityStartedListener(func(activityInfo *ActivityInfo, ctx context.Context, args []interface{}) {
-		startedCount++
+		startedCount.Inc()
 	})
 
 	env.SetOnLocalActivityCompletedListener(func(activityInfo *ActivityInfo, result Value, err error) {
@@ -1744,11 +1743,11 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListene
 		err = result.Get(&resultValue)
 		s.NoError(err)
 		s.Equal("hello mock", resultValue)
-		completedCount++
+		completedCount.Inc()
 	})
 
 	env.SetOnLocalActivityCanceledListener(func(activityInfo *ActivityInfo) {
-		canceledCount++
+		canceledCount.Inc()
 	})
 
 	env.ExecuteWorkflow(workflowFn)
@@ -1758,9 +1757,9 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListene
 	err := env.GetWorkflowResult(&result)
 	s.NoError(err)
 	env.AssertExpectations(s.T())
-	s.Equal(2, startedCount)
-	s.Equal(1, completedCount)
-	s.Equal(1, canceledCount)
+	s.Equal(int32(2), startedCount.Load())
+	s.Equal(int32(1), completedCount.Load())
+	s.Equal(int32(1), canceledCount.Load())
 	s.Equal("hello mock", result)
 	s.True(localActivityFnCancelled.Load())
 }

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -1714,7 +1714,10 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListene
 		ctx2, cancel := WithCancel(ctx)
 		f2 := ExecuteLocalActivity(ctx2, cancelledLocalActivityFn)
 
-		f.Get(ctx, nil)
+		err := f.Get(ctx, nil)
+		if err != nil {
+			return "", err
+		}
 		// Hack to avoid race condition. Never do anything similar in real production code
 		for startedCount.Load() < 2 {
 			time.Sleep(100 * time.Millisecond)
@@ -1726,8 +1729,8 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowLocalActivityWithMockAndListene
 			return "", err2
 		}
 
-		err := f.Get(ctx, &result)
-		return result, err
+		err3 := f.Get(ctx, &result)
+		return result, err3
 	}
 
 	env := s.NewTestWorkflowEnvironment()

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -165,24 +165,23 @@ type (
 	// Options is used to configure a worker instance.
 	Options = internal.WorkerOptions
 
-	// NonDeterministicWorkflowPolicy is an enum for configuring how client's decision task handler deals with
-	// mismatched history events (presumably arising from non-deterministic workflow definitions).
-	NonDeterministicWorkflowPolicy = internal.NonDeterministicWorkflowPolicy
+	// WorkflowPanicPolicy is used for configuring how worker deals with workflow
+	// code panicking which includes non backwards compatible changes to the workflow code without appropriate
+	// versioning (see workflow.GetVersion).
+	// The default behavior is to block workflow execution until the problem is fixed.
+	WorkflowPanicPolicy = internal.WorkflowPanicPolicy
 )
 
 const (
-	// NonDeterministicWorkflowPolicyBlockWorkflow is the default policy for handling detected non-determinism.
-	// This option simply logs to console with an error message that non-determinism is detected, but
-	// does *NOT* reply anything back to the server.
-	// It is chosen as default for backward compatibility reasons because it preserves the old behavior
-	// for handling non-determinism that we had before NonDeterministicWorkflowPolicy type was added to
-	// allow more configurability.
-	NonDeterministicWorkflowPolicyBlockWorkflow = internal.NonDeterministicWorkflowPolicyBlockWorkflow
-	// NonDeterministicWorkflowPolicyFailWorkflow behaves exactly the same as Ignore, up until the very
-	// end of processing a decision task.
-	// Whereas default does *NOT* reply anything back to the server, fail workflow replies back with a request
-	// to fail the workflow execution.
-	NonDeterministicWorkflowPolicyFailWorkflow = internal.NonDeterministicWorkflowPolicyFailWorkflow
+	// BlockWorkflow is the default WorkflowPanicPolicy policy for handling workflow panics and detected non-determinism.
+	// This option causes workflow to get stuck in the workflow task retry loop.
+	// It is expected that after the problem is discovered and fixed the workflows are going to continue
+	// without any additional manual intervention.
+	BlockWorkflow = internal.BlockWorkflow
+	// FailWorkflow WorkflowPanicPolicy immediately fails workflow execution if workflow code throws panic or
+	// detects non-determinism. This feature is convenient during development.
+	// WARNING: enabling this in production can cause all open workflows to fail on a single bug or bad deployment.
+	FailWorkflow = internal.FailWorkflow
 )
 
 // New creates an instance of worker for managing workflow and activity executions.


### PR DESCRIPTION
The NonDeterministicWorkflowPolicy is confusing as this policy applies to all panics in the workflow code including dereferencing a nil pointer for example.