### PR TITLE
Test env

### DIFF
--- a/internal/encoded.go
+++ b/internal/encoded.go
@@ -96,7 +96,9 @@ func (dc *defaultDataConverter) FromData(data []byte, to ...interface{}) error {
 		reflect.ValueOf(to[0]).Elem().SetBytes(data)
 		return nil
 	}
-
+	if len(data) == 0 {
+		return nil
+	}
 	encoder := &jsonEncoding{}
 
 	return encoder.Unmarshal(data, to)

--- a/internal/encoded_test.go
+++ b/internal/encoded_test.go
@@ -106,6 +106,9 @@ func (tdc *testDataConverter) ToData(value ...interface{}) ([]byte, error) {
 }
 
 func (tdc *testDataConverter) FromData(input []byte, valuePtr ...interface{}) error {
+	if len(input) == 0 {
+		return nil
+	}
 	dec := gob.NewDecoder(bytes.NewBuffer(input))
 	for i, obj := range valuePtr {
 		if err := dec.Decode(obj); err != nil {

--- a/internal/internal_event_handlers_test.go
+++ b/internal/internal_event_handlers_test.go
@@ -90,7 +90,7 @@ func TestDecodedValue(t *testing.T) {
 	testDecodeValueHelper(t, env)
 }
 
-func TestDecodedValue_WithDataConverter(t *testing.T) {
+func TestDecodedValueWithDataConverter(t *testing.T) {
 	t.Parallel()
 	env := &workflowEnvironmentImpl{
 		dataConverter: newTestDataConverter(),

--- a/internal/internal_task_handlers_test.go
+++ b/internal/internal_task_handlers_test.go
@@ -327,7 +327,7 @@ func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowExecutionStarted() {
 	t.testWorkflowTaskWorkflowExecutionStartedHelper(params)
 }
 
-func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowExecutionStarted_WithDataConverter() {
+func (t *TaskHandlersTestSuite) TestWorkflowTask_WorkflowExecutionStartedWithDataConverter() {
 	params := workerExecutionParameters{
 		TaskList:      testWorkflowTaskTasklist,
 		Identity:      "test-id-1",

--- a/internal/internal_utils_test.go
+++ b/internal/internal_utils_test.go
@@ -53,7 +53,7 @@ func TestNewValues(t *testing.T) {
 		Age:  heartbeatDetail2,
 	}
 	details = append(details, heartbeatDetail, heartbeatDetail2, heartbeatDetail3)
-	data, err := encodeArgs(nil, details)
+	data, err := encodeArgs(getDefaultDataConverter(), details)
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +69,7 @@ func TestNewValues(t *testing.T) {
 func TestNewValue(t *testing.T) {
 	t.Parallel()
 	heartbeatDetail := "status-report-to-workflow"
-	data, err := encodeArg(nil, heartbeatDetail)
+	data, err := encodeArg(getDefaultDataConverter(), heartbeatDetail)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -740,9 +740,6 @@ func validateFnFormat(fnType reflect.Type, isWorkflow bool) error {
 
 // encode multiple arguments(arguments to a function).
 func encodeArgs(dc DataConverter, args []interface{}) ([]byte, error) {
-	if dc == nil {
-		return getDefaultDataConverter().ToData(args...)
-	}
 	return dc.ToData(args...)
 }
 
@@ -759,9 +756,6 @@ func decodeArgs(dc DataConverter, fnType reflect.Type, data []byte) (result []re
 }
 
 func decodeArgsToValues(dc DataConverter, fnType reflect.Type, data []byte) (result []interface{}, err error) {
-	if dc == nil {
-		dc = getDefaultDataConverter()
-	}
 argsLoop:
 	for i := 0; i < fnType.NumIn(); i++ {
 		argT := fnType.In(i)
@@ -780,17 +774,11 @@ argsLoop:
 
 // encode single value(like return parameter).
 func encodeArg(dc DataConverter, arg interface{}) ([]byte, error) {
-	if dc == nil {
-		return getDefaultDataConverter().ToData(arg)
-	}
 	return dc.ToData(arg)
 }
 
 // decode single value(like return parameter).
 func decodeArg(dc DataConverter, data []byte, to interface{}) error {
-	if dc == nil {
-		return getDefaultDataConverter().FromData(data, to)
-	}
 	return dc.FromData(data, to)
 }
 

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -408,7 +408,7 @@ func (s *internalWorkerTestSuite) testDecisionTaskHandlerHelper(params workerExe
 	s.NoError(err)
 }
 
-func (s *internalWorkerTestSuite) TestDecisionTaskHandler_WithDataConverter() {
+func (s *internalWorkerTestSuite) TestDecisionTaskHandlerWithDataConverter() {
 	params := workerExecutionParameters{
 		Namespace:     testNamespace,
 		Identity:      "identity",
@@ -445,7 +445,7 @@ func (s *internalWorkerTestSuite) TestCreateWorker() {
 	worker.Stop()
 }
 
-func (s *internalWorkerTestSuite) TestCreateWorker_WithDataConverter() {
+func (s *internalWorkerTestSuite) TestCreateWorkerWithDataConverter() {
 	worker := createWorkerWithDataConverter(s.service)
 	err := worker.Start()
 	require.NoError(s.T(), err)
@@ -636,7 +636,7 @@ func (s *internalWorkerTestSuite) TestCompleteActivity() {
 	s.testCompleteActivityHelper(ClientOptions{})
 }
 
-func (s *internalWorkerTestSuite) TestCompleteActivity_WithDataConverter() {
+func (s *internalWorkerTestSuite) TestCompleteActivityWithDataConverter() {
 	opt := ClientOptions{DataConverter: newTestDataConverter()}
 	s.testCompleteActivityHelper(opt)
 }
@@ -687,7 +687,7 @@ func (s *internalWorkerTestSuite) TestRecordActivityHeartbeat() {
 	require.NotNil(s.T(), heartbeatRequest)
 }
 
-func (s *internalWorkerTestSuite) TestRecordActivityHeartbeat_WithDataConverter() {
+func (s *internalWorkerTestSuite) TestRecordActivityHeartbeatWithDataConverter() {
 	t := s.T()
 	dc := newTestDataConverter()
 	opt := ClientOptions{Namespace: "testNamespace", DataConverter: dc}
@@ -1030,7 +1030,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 	require.Equal(t, testErrorDetails{T: "testErrorStack4"}, td)
 }
 
-func TestActivityErrorWithDetails_WithDataConverter(t *testing.T) {
+func TestActivityErrorWithDetailsWithDataConverter(t *testing.T) {
 	dc := newTestDataConverter()
 	ctx := context.WithValue(context.Background(), activityEnvContextKey, &activityEnvironment{dataConverter: dc})
 	testActivityErrorWithDetailsHelper(ctx, t, dc)
@@ -1093,7 +1093,7 @@ func testActivityCancelledErrorHelper(ctx context.Context, t *testing.T, dataCon
 	require.Equal(t, testErrorDetails{T: "testErrorStack4"}, td)
 }
 
-func TestActivityCancelledError_WithDataConverter(t *testing.T) {
+func TestActivityCancelledErrorWithDataConverter(t *testing.T) {
 	dc := newTestDataConverter()
 	ctx := context.WithValue(context.Background(), activityEnvContextKey, &activityEnvironment{dataConverter: dc})
 	testActivityCancelledErrorHelper(ctx, t, dc)
@@ -1122,7 +1122,7 @@ func testActivityExecutionVariousTypesHelper(ctx context.Context, t *testing.T, 
 	require.Equal(t, 2, r.V)
 }
 
-func TestActivityExecutionVariousTypes_WithDataConverter(t *testing.T) {
+func TestActivityExecutionVariousTypesWithDataConverter(t *testing.T) {
 	dc := newTestDataConverter()
 	ctx := context.WithValue(context.Background(), activityEnvContextKey, &activityEnvironment{
 		dataConverter: dc,

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -70,8 +70,9 @@ func (ath noResponseActivityTaskHandler) BlockedOnExecuteCalled() error {
 type (
 	WorkersTestSuite struct {
 		suite.Suite
-		mockCtrl *gomock.Controller
-		service  *workflowservicemock.MockWorkflowServiceClient
+		mockCtrl      *gomock.Controller
+		service       *workflowservicemock.MockWorkflowServiceClient
+		dataConverter DataConverter
 	}
 )
 
@@ -79,6 +80,7 @@ type (
 func (s *WorkersTestSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
 	s.service = workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
+	s.dataConverter = getDefaultDataConverter()
 }
 
 func (s *WorkersTestSuite) TearDownTest() {
@@ -491,7 +493,7 @@ func (s *WorkersTestSuite) createLocalActivityMarkerDataForTest(activityID strin
 	}
 
 	// encode marker data
-	markerData, err := encodeArg(nil, lamd)
+	markerData, err := encodeArg(s.dataConverter, lamd)
 	s.NoError(err)
 	return markerData
 }

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1284,8 +1284,8 @@ func (d *decodeFutureImpl) Get(ctx Context, value interface{}) error {
 	if rf.Type().Kind() != reflect.Ptr {
 		return errors.New("value parameter is not a pointer")
 	}
-
-	err := deSerializeFunctionResult(d.fn, d.futureImpl.value.([]byte), value, getDataConverterFromWorkflowContext(ctx), d.channel.env.GetRegistry())
+	dataConverter := getDataConverterFromWorkflowContext(ctx)
+	err := dataConverter.FromData(d.futureImpl.value.([]byte), value)
 	if err != nil {
 		return err
 	}

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -1113,7 +1113,7 @@ func (workflowRun *workflowRunImpl) Get(ctx context.Context, valuePtr interface{
 		if rf.Type().Kind() != reflect.Ptr {
 			return errors.New("value parameter is not a pointer")
 		}
-		err = deSerializeFunctionResult(workflowRun.workflowFn, attributes.Result, valuePtr, workflowRun.dataConverter, workflowRun.registry)
+		err = workflowRun.dataConverter.FromData(attributes.Result, valuePtr)
 	case eventpb.EventType_WorkflowExecutionFailed:
 		attributes := closeEvent.GetWorkflowExecutionFailedEventAttributes()
 		err = constructError(attributes.GetReason(), attributes.Details, workflowRun.dataConverter)

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -272,6 +272,7 @@ type (
 		mockCtrl              *gomock.Controller
 		workflowServiceClient *workflowservicemock.MockWorkflowServiceClient
 		workflowClient        Client
+		dataConverter         DataConverter
 	}
 )
 
@@ -301,6 +302,7 @@ func (s *workflowRunSuite) SetupTest() {
 		Identity:     identity,
 	}
 	s.workflowClient = NewServiceClient(s.workflowServiceClient, nil, options)
+	s.dataConverter = getDefaultDataConverter()
 }
 
 func (s *workflowRunSuite) TearDownTest() {
@@ -358,7 +360,7 @@ func (s *workflowRunSuite) TestExecuteWorkflowWorkflowExecutionAlreadyStartedErr
 
 	eventType := eventpb.EventType_WorkflowExecutionCompleted
 	workflowResult := time.Hour * 59
-	encodedResult, _ := encodeArg(nil, workflowResult)
+	encodedResult, _ := encodeArg(s.dataConverter, workflowResult)
 	getResponse := &workflowservice.GetWorkflowExecutionHistoryResponse{
 		History: &eventpb.History{
 			Events: []*eventpb.HistoryEvent{
@@ -408,7 +410,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoIdInOptions() {
 
 	eventType := eventpb.EventType_WorkflowExecutionCompleted
 	workflowResult := time.Hour * 59
-	encodedResult, _ := encodeArg(nil, workflowResult)
+	encodedResult, _ := encodeArg(s.dataConverter, workflowResult)
 	getResponse := &workflowservice.GetWorkflowExecutionHistoryResponse{
 		History: &eventpb.History{
 			Events: []*eventpb.HistoryEvent{
@@ -748,9 +750,10 @@ func getGetWorkflowExecutionHistoryRequest(filterType filterpb.HistoryEventFilte
 type (
 	workflowClientTestSuite struct {
 		suite.Suite
-		mockCtrl *gomock.Controller
-		service  *workflowservicemock.MockWorkflowServiceClient
-		client   Client
+		mockCtrl      *gomock.Controller
+		service       *workflowservicemock.MockWorkflowServiceClient
+		client        Client
+		dataConverter DataConverter
 	}
 )
 
@@ -768,6 +771,7 @@ func (s *workflowClientTestSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
 	s.service = workflowservicemock.NewMockWorkflowServiceClient(s.mockCtrl)
 	s.client = NewServiceClient(s.service, nil, ClientOptions{})
+	s.dataConverter = getDefaultDataConverter()
 }
 
 func (s *workflowClientTestSuite) TearDownTest() {
@@ -988,27 +992,27 @@ func (s *workflowClientTestSuite) SignalWithStartWorkflowWithMemoAndSearchAttr()
 
 func (s *workflowClientTestSuite) TestGetWorkflowMemo() {
 	var input1 map[string]interface{}
-	result1, err := getWorkflowMemo(input1, nil)
+	result1, err := getWorkflowMemo(input1, s.dataConverter)
 	s.NoError(err)
 	s.Nil(result1)
 
 	input1 = make(map[string]interface{})
-	result2, err := getWorkflowMemo(input1, nil)
+	result2, err := getWorkflowMemo(input1, s.dataConverter)
 	s.NoError(err)
 	s.NotNil(result2)
 	s.Equal(0, len(result2.Fields))
 
 	input1["t1"] = "v1"
-	result3, err := getWorkflowMemo(input1, nil)
+	result3, err := getWorkflowMemo(input1, s.dataConverter)
 	s.NoError(err)
 	s.NotNil(result3)
 	s.Equal(1, len(result3.Fields))
 	var resultString string
-	_ = decodeArg(nil, result3.Fields["t1"], &resultString)
+	_ = decodeArg(s.dataConverter, result3.Fields["t1"], &resultString)
 	s.Equal("v1", resultString)
 
 	input1["non-serializable"] = make(chan int)
-	_, err = getWorkflowMemo(input1, nil)
+	_, err = getWorkflowMemo(input1, s.dataConverter)
 	s.Error(err)
 }
 
@@ -1030,7 +1034,7 @@ func (s *workflowClientTestSuite) TestSerializeSearchAttributes() {
 	s.NotNil(result3)
 	s.Equal(1, len(result3.IndexedFields))
 	var resultString string
-	_ = decodeArg(nil, result3.IndexedFields["t1"], &resultString)
+	_ = decodeArg(s.dataConverter, result3.IndexedFields["t1"], &resultString)
 	s.Equal("v1", resultString)
 
 	input1["non-serializable"] = make(chan int)

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -886,7 +886,7 @@ func (s *workflowClientTestSuite) TestStartWorkflow_WithContext() {
 	s.Equal(createResponse.GetRunId(), resp.RunID)
 }
 
-func (s *workflowClientTestSuite) TestStartWorkflow_WithDataConverter() {
+func (s *workflowClientTestSuite) TestStartWorkflowWithDataConverter() {
 	dc := newTestDataConverter()
 	s.client = NewServiceClient(s.service, nil, ClientOptions{DataConverter: dc})
 	client, ok := s.client.(*WorkflowClient)

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -90,7 +90,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunction() {
 	env.AssertExpectations(s.T())
 }
 
-func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunction_WithDataConverter() {
+func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunctionWithDataConverter() {
 	mockActivity := func(ctx context.Context, msg string) (string, error) {
 		return "mock_" + msg, nil
 	}
@@ -618,7 +618,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflow_Basic() {
 	s.Equal("hello_activity hello_world", actualResult)
 }
 
-func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflow_Basic_WithDataConverter() {
+func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflow_BasicWithDataConverter() {
 	workflowFn := func(ctx Context) (string, error) {
 		ctx = WithActivityOptions(ctx, s.activityOptions)
 		var helloActivityResult string

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -78,8 +78,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityMockFunction() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
-	env.RegisterActivity(testActivityHello)
-	env.OnActivity(testActivityHello, mock.Anything, mock.Anything).Return(mockActivity).Once()
+	env.OnActivity("testActivityHello", mock.Anything, mock.Anything).Return(mockActivity).Once()
 	env.RegisterWorkflow(testWorkflowHello)
 	env.ExecuteWorkflow(testWorkflowHello)
 

--- a/internal/json_encoding.go
+++ b/internal/json_encoding.go
@@ -54,6 +54,9 @@ func (g jsonEncoding) Marshal(objs []interface{}) ([]byte, error) {
 
 // Unmarshal decodes a byte array into the passed in objects
 func (g jsonEncoding) Unmarshal(data []byte, objs []interface{}) error {
+	if len(data) == 0 {
+		return nil
+	}
 	dec := json.NewDecoder(bytes.NewBuffer(data))
 	for i, obj := range objs {
 		if err := dec.Decode(obj); err != nil {

--- a/internal/session_test.go
+++ b/internal/session_test.go
@@ -84,6 +84,7 @@ func (s *SessionTestSuite) TestCreationCompletion() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{EnableSessionWorker: true})
 	env.RegisterWorkflow(workflowFn)
 	env.OnActivity(sessionCreationActivityName, mock.Anything, mock.Anything).Return(sessionCreationActivity).Once()
 	env.OnActivity(sessionCompletionActivityName, mock.Anything, mock.Anything).Return(sessionCompletionActivity).Once()
@@ -136,6 +137,7 @@ func (s *SessionTestSuite) TestCreationWithClosedSessionContext() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{EnableSessionWorker: true})
 	env.RegisterWorkflow(workflowFn)
 	env.OnActivity(sessionCreationActivityName, mock.Anything, mock.Anything).Return(sessionCreationActivity).Once()
 	env.OnActivity(sessionCompletionActivityName, mock.Anything, mock.Anything).Return(sessionCompletionActivity).Once()
@@ -169,6 +171,7 @@ func (s *SessionTestSuite) TestCreationWithFailedSessionContext() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{EnableSessionWorker: true})
 	env.RegisterWorkflow(workflowFn)
 	env.OnActivity(sessionCreationActivityName, mock.Anything, mock.Anything).Return(sessionCreationActivity).Once()
 	env.OnActivity(sessionCompletionActivityName, mock.Anything, mock.Anything).Return(sessionCompletionActivity).Once()
@@ -283,6 +286,7 @@ func (s *SessionTestSuite) TestRecreation() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{EnableSessionWorker: true})
 	env.RegisterWorkflow(workflowFn)
 	env.OnActivity(sessionCreationActivityName, mock.Anything, mock.Anything).Return(sessionCreationActivity).Once()
 	env.OnActivity(sessionCompletionActivityName, mock.Anything, mock.Anything).Return(sessionCompletionActivity).Once()
@@ -314,6 +318,7 @@ func (s *SessionTestSuite) TestMaxConcurrentSession_CreationOnly() {
 	env.RegisterWorkflow(workflowFn)
 	env.SetWorkerOptions(WorkerOptions{
 		MaxConcurrentSessionExecutionSize: maxConcurrentSessionExecutionSize,
+		EnableSessionWorker:               true,
 	})
 	env.ExecuteWorkflow(workflowFn)
 
@@ -356,6 +361,7 @@ func (s *SessionTestSuite) TestMaxConcurrentSession_WithRecreation() {
 	env.RegisterWorkflow(workflowFn)
 	env.SetWorkerOptions(WorkerOptions{
 		MaxConcurrentSessionExecutionSize: maxConcurrentSessionExecutionSize,
+		EnableSessionWorker:               true,
 	})
 	env.OnActivity(sessionCreationActivityName, mock.Anything, mock.Anything).Return(sessionCreationActivity)
 	env.ExecuteWorkflow(workflowFn)
@@ -390,6 +396,7 @@ func (s *SessionTestSuite) TestSessionTaskList() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{EnableSessionWorker: true})
 	env.RegisterActivity(testSessionActivity)
 
 	var taskListUsed []string
@@ -444,6 +451,7 @@ func (s *SessionTestSuite) TestSessionRecreationTaskList() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{EnableSessionWorker: true})
 	env.RegisterActivity(testSessionActivity)
 
 	var taskListUsed []string
@@ -562,6 +570,7 @@ func (s *SessionTestSuite) TestCompletionFailed() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{EnableSessionWorker: true})
 	env.RegisterWorkflow(workflowFn)
 	env.OnActivity(sessionCreationActivityName, mock.Anything, mock.Anything).Return(sessionCreationActivity).Once()
 	env.OnActivity(sessionCompletionActivityName, mock.Anything, mock.Anything).Return(errors.New("some random error")).Once()
@@ -589,6 +598,7 @@ func (s *SessionTestSuite) TestUserTimerWithinSession() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{EnableSessionWorker: true})
 	env.RegisterWorkflow(workflowFn)
 	env.ExecuteWorkflow(workflowFn)
 
@@ -626,6 +636,7 @@ func (s *SessionTestSuite) TestActivityRetryWithinSession() {
 	}
 
 	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(WorkerOptions{EnableSessionWorker: true})
 	env.RegisterActivity(testSessionActivity)
 	env.OnActivity(testSessionActivity, mock.Anything, mock.Anything).Return("", errors.New("some random error"))
 	env.ExecuteWorkflow(workflowFn)

--- a/internal/workflow_testsuite.go
+++ b/internal/workflow_testsuite.go
@@ -287,15 +287,23 @@ func (t *TestWorkflowEnvironment) OnActivity(activity interface{}, args ...inter
 			panic(err)
 		}
 		fnName := getActivityFunctionName(t.impl.registry, activity)
+		t.impl.registry.RegisterActivityWithOptions(activity, RegisterActivityOptions{DisableAlreadyRegisteredCheck: true})
 		call = t.Mock.On(fnName, args...)
 
 	case reflect.String:
-		call = t.Mock.On(activity.(string), args...)
+		name := activity.(string)
+		t.impl.registry.RegisterActivityWithOptions(mockDummyActivity, RegisterActivityOptions{Name: name, DisableAlreadyRegisteredCheck: true})
+		call = t.Mock.On(name, args...)
 	default:
 		panic("activity must be function or string")
 	}
 
 	return t.wrapCall(call)
+}
+
+// Used to register mocks by string name
+func mockDummyActivity() error {
+	panic("should never be called as it is mocked")
 }
 
 // ErrMockStartChildWorkflowFailed is special error used to indicate the mocked child workflow should fail to start.

--- a/internal/workflow_testsuite_test.go
+++ b/internal/workflow_testsuite_test.go
@@ -101,6 +101,7 @@ func TestUnregisteredActivity(t *testing.T) {
 	t.Parallel()
 	testSuite := &WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
+	env.RegisterActivity(helloWorldAct)
 	workflow := func(ctx Context) error {
 		ctx = WithActivityOptions(ctx, ActivityOptions{
 			ScheduleToStartTimeout: time.Minute,


### PR DESCRIPTION
- Added support to `WorkflowTestEnvironment` for mocking activities by name without explicit registration. This code which didn't work before as "testActivityHello" is not registered explicitly with the test environment is now valid. The problem was that to register an activity its implementation was needed which is might be not available for activities defined in other packages.

```
	env := s.NewTestWorkflowEnvironment()
	env.OnActivity("testActivityHello", mock.Anything, mock.Anything).Return("foo", nil).Once()
	env.RegisterWorkflow(testWorkflowHello)
	env.ExecuteWorkflow(testWorkflowHello)

```
- Refactored deserialization of activity and child workflow results to use pointer passed to the `Future.Get` method as a target type. This removes a lot of unnecessary complexity.

- Removed support for nil converter to many serialization/deserialization APIs as it is dangerous to have such code which was intended only for testing.

- Initialize session support in `WorkflowTestEnvironment` only when `FactoryOptions.EnableSessionWorker` is true.