### PR TITLE
Convert Header message to use Payload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/uber-go/tally v3.3.15+incompatible
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
-	go.temporal.io/temporal-proto v0.20.27
+	go.temporal.io/temporal-proto v0.20.28
 	go.uber.org/atomic v1.6.0
 	go.uber.org/goleak v1.0.0
 	go.uber.org/zap v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMW
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.temporal.io/temporal-proto v0.20.27 h1:g/UMo4TZyUGCGCAsvz81IIlkN6YQW7S5Ua4bwpjECvQ=
-go.temporal.io/temporal-proto v0.20.27/go.mod h1:Lv8L8YBpbp0Z7V5nbvw5UD0j7x0isebhCOIDLkBqn6s=
+go.temporal.io/temporal-proto v0.20.28 h1:syCkMj1bBEqPCj4dKmPQksBKH3qXeZ+PayfsBMdQEOY=
+go.temporal.io/temporal-proto v0.20.28/go.mod h1:Lv8L8YBpbp0Z7V5nbvw5UD0j7x0isebhCOIDLkBqn6s=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/goleak v1.0.0 h1:qsup4IcBdlmsnGfqyLl4Ntn3C2XCCuKAE7DwHpScyUo=

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	commonpb "go.temporal.io/temporal-proto/common"
@@ -437,8 +438,10 @@ func Test_ContinueAsNewError(t *testing.T) {
 		return NewContinueAsNewError(ctx, continueAsNewWfName, a1, a2)
 	}
 
+	headerValue, err := DefaultDataConverter.ToData("test-data")
+	assert.NoError(t, err)
 	header := &commonpb.Header{
-		Fields: map[string][]byte{"test": []byte("test-data")},
+		Fields: map[string]*commonpb.Payload{"test": headerValue},
 	}
 
 	s := &WorkflowTestSuite{
@@ -450,7 +453,7 @@ func Test_ContinueAsNewError(t *testing.T) {
 		Name: continueAsNewWfName,
 	})
 	wfEnv.ExecuteWorkflow(continueAsNewWorkflowFn, 101, "another random string")
-	err := wfEnv.GetWorkflowError()
+	err = wfEnv.GetWorkflowError()
 
 	require.Error(t, err)
 	continueAsNewErr, ok := err.(*ContinueAsNewError)

--- a/internal/headers_test.go
+++ b/internal/headers_test.go
@@ -91,10 +91,7 @@ func TestHeaderWriter(t *testing.T) {
 			t.Parallel()
 			writer := NewHeaderWriter(test.initial)
 			for key, val := range test.vals {
-				var decodedValue string
-				err := DefaultDataConverter.FromData(val, &decodedValue)
-				assert.NoError(t, err)
-				writer.Set(key, decodedValue)
+				writer.Set(key, val)
 			}
 			assert.Equal(t, test.expected, test.initial)
 		})
@@ -144,7 +141,7 @@ func TestHeaderReader(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			reader := NewHeaderReader(test.header)
-			err := reader.ForEachKey(func(key string, val string) error {
+			err := reader.ForEachKey(func(key string, _ *commonpb.Payload) error {
 				if _, ok := test.keys[key]; !ok {
 					return assert.AnError
 				}

--- a/internal/internal_workflow.go
+++ b/internal/internal_workflow.go
@@ -1194,7 +1194,7 @@ func getContextPropagatorsFromWorkflowContext(ctx Context) []ContextPropagator {
 
 func getHeadersFromContext(ctx Context) *commonpb.Header {
 	header := &commonpb.Header{
-		Fields: make(map[string][]byte),
+		Fields: make(map[string]*commonpb.Payload),
 	}
 	contextPropagators := getContextPropagatorsFromWorkflowContext(ctx)
 	for _, ctxProp := range contextPropagators {

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -948,7 +948,7 @@ func (wc *WorkflowClient) CloseConnection() error {
 
 func (wc *WorkflowClient) getWorkflowHeader(ctx context.Context) *commonpb.Header {
 	header := &commonpb.Header{
-		Fields: make(map[string][]byte),
+		Fields: make(map[string]*commonpb.Payload),
 	}
 	writer := NewHeaderWriter(header)
 	for _, ctxProp := range wc.contextPropagators {

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -92,7 +92,7 @@ func (s *stringMapPropagator) Inject(ctx context.Context, writer HeaderWriter) e
 		if !ok {
 			return fmt.Errorf("unable to extract key from context %v", key)
 		}
-		writer.Set(key, []byte(value))
+		writer.Set(key, value)
 	}
 	return nil
 }
@@ -104,16 +104,16 @@ func (s *stringMapPropagator) InjectFromWorkflow(ctx Context, writer HeaderWrite
 		if !ok {
 			return fmt.Errorf("unable to extract key from context %v", key)
 		}
-		writer.Set(key, []byte(value))
+		writer.Set(key, value)
 	}
 	return nil
 }
 
 // Extract extracts values from headers and puts them into context
 func (s *stringMapPropagator) Extract(ctx context.Context, reader HeaderReader) (context.Context, error) {
-	if err := reader.ForEachKey(func(key string, value []byte) error {
+	if err := reader.ForEachKey(func(key string, value string) error {
 		if _, ok := s.keys[key]; ok {
-			ctx = context.WithValue(ctx, contextKey(key), string(value))
+			ctx = context.WithValue(ctx, contextKey(key), value)
 		}
 		return nil
 	}); err != nil {
@@ -124,9 +124,9 @@ func (s *stringMapPropagator) Extract(ctx context.Context, reader HeaderReader) 
 
 // ExtractToWorkflow extracts values from headers and puts them into context
 func (s *stringMapPropagator) ExtractToWorkflow(ctx Context, reader HeaderReader) (Context, error) {
-	if err := reader.ForEachKey(func(key string, value []byte) error {
+	if err := reader.ForEachKey(func(key string, value string) error {
 		if _, ok := s.keys[key]; ok {
-			ctx = WithValue(ctx, contextKey(key), string(value))
+			ctx = WithValue(ctx, contextKey(key), value)
 		}
 		return nil
 	}); err != nil {

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -61,7 +61,7 @@ func (s *WorkflowTestSuiteUnitTest) SetupSuite() {
 		ScheduleToCloseTimeout: 3 * time.Second,
 	}
 	s.header = &commonpb.Header{
-		Fields: map[string][]byte{"test": []byte("test-data")},
+		Fields: map[string]*commonpb.Payload{"test": encodeString(s.T(), "test-data")},
 	}
 	s.contextPropagators = []ContextPropagator{NewStringMapPropagator([]string{"test"})}
 }
@@ -387,8 +387,8 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityWithHeaderContext() {
 	}
 
 	s.SetHeader(&commonpb.Header{
-		Fields: map[string][]byte{
-			testHeader: []byte("test-data"),
+		Fields: map[string]*commonpb.Payload{
+			testHeader: encodeString(s.T(), "test-data"),
 		},
 	})
 
@@ -1609,8 +1609,8 @@ func (s *WorkflowTestSuiteUnitTest) Test_WorkflowHeaderContext() {
 
 	s.SetContextPropagators([]ContextPropagator{NewStringMapPropagator([]string{testHeader})})
 	s.SetHeader(&commonpb.Header{
-		Fields: map[string][]byte{
-			testHeader: []byte("test-data"),
+		Fields: map[string]*commonpb.Payload{
+			testHeader: encodeString(s.T(), "test-data"),
 		},
 	})
 

--- a/internal/tracer.go
+++ b/internal/tracer.go
@@ -36,8 +36,8 @@ type tracingReader struct {
 }
 
 func (t tracingReader) ForeachKey(handler func(key, val string) error) error {
-	return t.reader.ForEachKey(func(k string, v []byte) error {
-		return handler(k, string(v))
+	return t.reader.ForEachKey(func(k string, v string) error {
+		return handler(k, v)
 	})
 }
 
@@ -46,7 +46,7 @@ type tracingWriter struct {
 }
 
 func (t tracingWriter) Set(key, val string) {
-	t.writer.Set(key, []byte(val))
+	t.writer.Set(key, val)
 }
 
 // tracingContextPropagator implements the ContextPropagator interface for

--- a/internal/tracer.go
+++ b/internal/tracer.go
@@ -32,10 +32,12 @@ import (
 	"go.uber.org/zap"
 )
 
-// Must impement opentracing.TextMapReader
 type tracingReader struct {
 	reader HeaderReader
 }
+
+// This is important requirement for t.tracer.Extract to work.
+var _ opentracing.TextMapReader = (*tracingReader)(nil)
 
 func (t tracingReader) ForeachKey(handler func(key, val string) error) error {
 	return t.reader.ForEachKey(func(k string, v *commonpb.Payload) error {
@@ -48,10 +50,12 @@ func (t tracingReader) ForeachKey(handler func(key, val string) error) error {
 	})
 }
 
-// Must impement opentracing.TextMapWriter
 type tracingWriter struct {
 	writer HeaderWriter
 }
+
+// This is important requirement for t.tracer.Inject to work.
+var _ opentracing.TextMapWriter = (*tracingWriter)(nil)
 
 func (t tracingWriter) Set(key, val string) {
 	encodedValue, _ := DefaultDataConverter.ToData(val)

--- a/internal/tracer_test.go
+++ b/internal/tracer_test.go
@@ -47,7 +47,7 @@ func TestTracingContextPropagator(t *testing.T) {
 	ctx := context.Background()
 	ctx = opentracing.ContextWithSpan(ctx, span)
 	header := &commonpb.Header{
-		Fields: map[string][]byte{},
+		Fields: map[string]*commonpb.Payload{},
 	}
 
 	err = ctxProp.Inject(ctx, NewHeaderWriter(header))
@@ -66,7 +66,7 @@ func TestTracingContextPropagatorNoSpan(t *testing.T) {
 	ctxProp := NewTracingContextPropagator(zap.NewNop(), opentracing.NoopTracer{})
 
 	header := &commonpb.Header{
-		Fields: map[string][]byte{},
+		Fields: map[string]*commonpb.Payload{},
 	}
 	err := ctxProp.Inject(context.Background(), NewHeaderWriter(header))
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestTracingContextPropagatorWorkflowContext(t *testing.T) {
 	assert.NotNil(t, span.Context())
 	ctx := contextWithSpan(Background(), span.Context())
 	header := &commonpb.Header{
-		Fields: map[string][]byte{},
+		Fields: map[string]*commonpb.Payload{},
 	}
 
 	err = ctxProp.InjectFromWorkflow(ctx, NewHeaderWriter(header))
@@ -111,7 +111,7 @@ func TestTracingContextPropagatorWorkflowContextNoSpan(t *testing.T) {
 	ctxProp := NewTracingContextPropagator(zap.NewNop(), opentracing.NoopTracer{})
 
 	header := &commonpb.Header{
-		Fields: map[string][]byte{},
+		Fields: map[string]*commonpb.Payload{},
 	}
 	err := ctxProp.InjectFromWorkflow(Background(), NewHeaderWriter(header))
 	require.NoError(t, err)

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -695,7 +695,7 @@ func (wc *workflowEnvironmentInterceptor) ExecuteChildWorkflow(ctx Context, chil
 
 func getWorkflowHeader(ctx Context, ctxProps []ContextPropagator) *commonpb.Header {
 	header := &commonpb.Header{
-		Fields: make(map[string][]byte),
+		Fields: make(map[string]*commonpb.Payload),
 	}
 	writer := NewHeaderWriter(header)
 	for _, ctxProp := range ctxProps {


### PR DESCRIPTION
Last replacement of `bytes` with `Payload` according to https://github.com/temporalio/temporal/issues/107.