### PR TITLE
Remove GRPCDialer

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -61,11 +61,8 @@ type (
 	// Options are optional parameters for Client creation.
 	Options = internal.ClientOptions
 
-	// GRPCDialer can be used to set custom gRPC connection creation logic.
-	GRPCDialer = internal.GRPCDialer
-
-	// GRPCDialerParams are passed to GRPCDialer and must be used to create gRPC connection.
-	GRPCDialerParams = internal.GRPCDialerParams
+	// ConnectionParameters are passed to GRPCDialer and must be used to create gRPC connection.
+	ConnectionParameters = internal.ConnectionParameters
 
 	// StartWorkflowOptions configuration parameters for starting a workflow execution.
 	StartWorkflowOptions = internal.StartWorkflowOptions

--- a/client/client.go
+++ b/client/client.go
@@ -61,9 +61,6 @@ type (
 	// Options are optional parameters for Client creation.
 	Options = internal.ClientOptions
 
-	// ConnectionParameters are passed to GRPCDialer and must be used to create gRPC connection.
-	ConnectionParameters = internal.ConnectionParameters
-
 	// StartWorkflowOptions configuration parameters for starting a workflow execution.
 	StartWorkflowOptions = internal.StartWorkflowOptions
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -376,18 +376,6 @@ type (
 		// Optional: Sets ContextPropagators that allows users to control the context information passed through a workflow
 		// default: no ContextPropagators
 		ContextPropagators []ContextPropagator
-
-		// Optional: Sets GRPCDialer that can be used to create gRPC connection
-		// GRPCDialer must add params.RequiredInterceptors and set params.DefaultServiceConfig if round-robin load balancer needs to be enabled:
-		// func customGRPCDialer(params GRPCDialerParams) (*grpc.ClientConn, error) {
-		//	return grpc.Dial(params.HostPort,
-		//		grpc.WithInsecure(),                                            // Replace this with required transport security if needed
-		//		grpc.WithChainUnaryInterceptor(params.RequiredInterceptors...), // Add custom interceptors here but params.RequiredInterceptors must be added anyway.
-		//		grpc.WithDefaultServiceConfig(params.DefaultServiceConfig),     // DefaultServiceConfig enables round-robin. Any valid gRPC service config can be used here (https://github.com/grpc/grpc/blob/master/doc/service_config.md).
-		//	)
-		// }
-		// default: defaultGRPCDialer (same as above)
-		GRPCDialer GRPCDialer
 	}
 
 	// StartWorkflowOptions configuration parameters for starting a workflow execution.
@@ -563,11 +551,7 @@ func NewClient(options ClientOptions) (Client, error) {
 		options.HostPort = LocalHostPort
 	}
 
-	if options.GRPCDialer == nil {
-		options.GRPCDialer = defaultGRPCDialer
-	}
-
-	connection, err := options.GRPCDialer(GRPCDialerParams{
+	connection, err := dial(ConnectionParameters{
 		HostPort:             options.HostPort,
 		RequiredInterceptors: requiredInterceptors(options.MetricsScope),
 		DefaultServiceConfig: defaultServiceConfig,
@@ -622,11 +606,7 @@ func NewNamespaceClient(options ClientOptions) (NamespaceClient, error) {
 		options.HostPort = LocalHostPort
 	}
 
-	if options.GRPCDialer == nil {
-		options.GRPCDialer = defaultGRPCDialer
-	}
-
-	connection, err := options.GRPCDialer(GRPCDialerParams{
+	connection, err := dial(ConnectionParameters{
 		HostPort:             options.HostPort,
 		RequiredInterceptors: requiredInterceptors(options.MetricsScope),
 		DefaultServiceConfig: defaultServiceConfig,

--- a/internal/client.go
+++ b/internal/client.go
@@ -551,7 +551,7 @@ func NewClient(options ClientOptions) (Client, error) {
 		options.HostPort = LocalHostPort
 	}
 
-	connection, err := dial(ConnectionParameters{
+	connection, err := dial(connectionParameters{
 		HostPort:             options.HostPort,
 		RequiredInterceptors: requiredInterceptors(options.MetricsScope),
 		DefaultServiceConfig: defaultServiceConfig,
@@ -606,7 +606,7 @@ func NewNamespaceClient(options ClientOptions) (NamespaceClient, error) {
 		options.HostPort = LocalHostPort
 	}
 
-	connection, err := dial(ConnectionParameters{
+	connection, err := dial(connectionParameters{
 		HostPort:             options.HostPort,
 		RequiredInterceptors: requiredInterceptors(options.MetricsScope),
 		DefaultServiceConfig: defaultServiceConfig,

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -36,8 +36,8 @@ import (
 )
 
 type (
-	// ConnectionParameters are passed to GRPCDialer and must be used to create gRPC connection.
-	ConnectionParameters struct {
+	// connectionParameters are passed to GRPCDialer and must be used to create gRPC connection.
+	connectionParameters struct {
 		HostPort             string
 		RequiredInterceptors []grpc.UnaryClientInterceptor
 		DefaultServiceConfig string
@@ -52,7 +52,7 @@ const (
 	defaultServiceConfig = `{"loadBalancingConfig": [{"round_robin":{}}]}`
 )
 
-func dial(params ConnectionParameters) (*grpc.ClientConn, error) {
+func dial(params connectionParameters) (*grpc.ClientConn, error) {
 	return grpc.Dial(params.HostPort,
 		grpc.WithInsecure(),
 		grpc.WithChainUnaryInterceptor(params.RequiredInterceptors...),

--- a/internal/grpc_dialer.go
+++ b/internal/grpc_dialer.go
@@ -36,15 +36,12 @@ import (
 )
 
 type (
-	// GRPCDialerParams are passed to GRPCDialer and must be used to create gRPC connection.
-	GRPCDialerParams struct {
+	// ConnectionParameters are passed to GRPCDialer and must be used to create gRPC connection.
+	ConnectionParameters struct {
 		HostPort             string
 		RequiredInterceptors []grpc.UnaryClientInterceptor
 		DefaultServiceConfig string
 	}
-
-	// GRPCDialer creates gRPC connection.
-	GRPCDialer func(params GRPCDialerParams) (*grpc.ClientConn, error)
 )
 
 const (
@@ -55,7 +52,7 @@ const (
 	defaultServiceConfig = `{"loadBalancingConfig": [{"round_robin":{}}]}`
 )
 
-func defaultGRPCDialer(params GRPCDialerParams) (*grpc.ClientConn, error) {
+func dial(params ConnectionParameters) (*grpc.ClientConn, error) {
 	return grpc.Dial(params.HostPort,
 		grpc.WithInsecure(),
 		grpc.WithChainUnaryInterceptor(params.RequiredInterceptors...),


### PR DESCRIPTION
Removing GRPCDialer - we will later introduce an object that settings would be set on and we would apply against our defaults.