### PR TITLE
Bump SDK version

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -31,7 +31,7 @@ package internal
 // This represents API changes visible to Temporal SDK consumers, i.e. developers
 // that are writing workflows. So every time we change API that can affect them we have to change this number.
 // Format: MAJOR.MINOR.PATCH
-const SDKVersion = "0.20.0"
+const SDKVersion = "0.23.0"
 
 // SDKFeatureVersion is a semver that represents the feature set version of this Temporal SDK support.
 // This can be used for client capability check, on Temporal server, for backward compatibility.


### PR DESCRIPTION
This will prevent customer from using old server versions with new SDK.