### PR TITLE
Rename CloseConnection to Close

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -352,8 +352,8 @@ type (
 		//  - EntityNotExistError
 		DescribeTaskList(ctx context.Context, tasklist string, tasklistType tasklistpb.TaskListType) (*workflowservice.DescribeTaskListResponse, error)
 
-		// CloseConnection closes underlying gRPC connection.
-		CloseConnection()
+		// Close client and clean up underlying resources.
+		Close()
 	}
 
 	// NamespaceClient is the client for managing operations on the namespace.
@@ -383,8 +383,8 @@ type (
 		//	- InternalServiceError
 		Update(ctx context.Context, request *workflowservice.UpdateNamespaceRequest) error
 
-		// CloseConnection closes underlying gRPC connection.
-		CloseConnection()
+		// Close client and clean up underlying resources.
+		Close()
 	}
 )
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -312,8 +312,8 @@ type (
 		//  - EntityNotExistError
 		DescribeTaskList(ctx context.Context, tasklist string, tasklistType tasklistpb.TaskListType) (*workflowservice.DescribeTaskListResponse, error)
 
-		// CloseConnection closes underlying gRPC connection.
-		CloseConnection()
+		// Close client and clean up underlying resources.
+		Close()
 	}
 
 	// ClientOptions are optional parameters for Client creation.
@@ -513,8 +513,8 @@ type (
 		//	- InternalServiceError
 		Update(ctx context.Context, request *workflowservice.UpdateNamespaceRequest) error
 
-		// CloseConnection closes underlying gRPC connection.
-		CloseConnection()
+		// Close client and clean up underlying resources.
+		Close()
 	}
 
 	// WorkflowIDReusePolicy defines workflow ID reuse behavior.

--- a/internal/internal_retry.go
+++ b/internal/internal_retry.go
@@ -78,5 +78,5 @@ func isServiceTransientError(err error) bool {
 		*serviceerror.CancellationAlreadyRequested:
 		return false
 	}
-	return err != errShutdown
+	return err != errStop
 }

--- a/internal/internal_worker.go
+++ b/internal/internal_worker.go
@@ -292,7 +292,7 @@ func newWorkflowTaskWorkerInternal(taskHandler WorkflowTaskHandler, service work
 		taskWorker:        poller,
 		identity:          params.Identity,
 		workerType:        "DecisionWorker",
-		shutdownTimeout:   params.WorkerStopTimeout},
+		stopTimeout:       params.WorkerStopTimeout},
 		params.Logger,
 		params.MetricsScope,
 		nil,
@@ -315,7 +315,7 @@ func newWorkflowTaskWorkerInternal(taskHandler WorkflowTaskHandler, service work
 		taskWorker:        localActivityTaskPoller,
 		identity:          params.Identity,
 		workerType:        "LocalActivityWorker",
-		shutdownTimeout:   params.WorkerStopTimeout},
+		stopTimeout:       params.WorkerStopTimeout},
 		params.Logger,
 		params.MetricsScope,
 		nil,
@@ -356,7 +356,7 @@ func (ww *workflowWorker) Run() error {
 	return nil
 }
 
-// Shutdown the worker.
+// Stop the worker.
 func (ww *workflowWorker) Stop() {
 	close(ww.stopC)
 	// TODO: remove the stop methods in favor of the workerStopChannel
@@ -445,7 +445,7 @@ func newActivityTaskWorker(taskHandler ActivityTaskHandler, service workflowserv
 			taskWorker:        poller,
 			identity:          workerParams.Identity,
 			workerType:        "ActivityWorker",
-			shutdownTimeout:   workerParams.WorkerStopTimeout,
+			stopTimeout:       workerParams.WorkerStopTimeout,
 			userContextCancel: workerParams.UserContextCancel},
 		workerParams.Logger,
 		workerParams.MetricsScope,
@@ -482,7 +482,7 @@ func (aw *activityWorker) Run() error {
 	return nil
 }
 
-// Shutdown the worker.
+// Stop the worker.
 func (aw *activityWorker) Stop() {
 	close(aw.stopC)
 	aw.worker.Stop()
@@ -962,7 +962,7 @@ func (aw *AggregatedWorker) RegisterActivityWithOptions(a interface{}, options R
 	aw.registry.RegisterActivityWithOptions(a, options)
 }
 
-// Start starts the worker in a non-blocking fashion
+// Start the worker in a non-blocking fashion.
 func (aw *AggregatedWorker) Start() error {
 	if err := initBinaryChecksum(); err != nil {
 		return fmt.Errorf("failed to get executable checksum: %v", err)
@@ -1076,8 +1076,8 @@ func getBinaryChecksum() string {
 	return binaryChecksum
 }
 
-// Run is a blocking start and cleans up resources when killed
-// returns error only if it fails to start the worker
+// Run the worker in a blocking fashion. Stop the worker when process is killed with SIGINT or SIGTERM.
+// Returns error only if worker fails to start.
 func (aw *AggregatedWorker) Run() error {
 	if err := aw.Start(); err != nil {
 		return err
@@ -1088,7 +1088,7 @@ func (aw *AggregatedWorker) Run() error {
 	return nil
 }
 
-// Stop cleans up any resources opened by worker
+// Stop the worker.
 func (aw *AggregatedWorker) Stop() {
 	if !isInterfaceNil(aw.workflowWorker) {
 		aw.workflowWorker.Stop()

--- a/internal/internal_workers_test.go
+++ b/internal/internal_workers_test.go
@@ -188,7 +188,7 @@ func (s *WorkersTestSuite) TestActivityWorkerStop() {
 	_ = activityTaskHandler.BlockedOnExecuteCalled()
 	go worker.Stop()
 
-	<-worker.worker.shutdownCh
+	<-worker.worker.stopCh
 	err := ctx.Err()
 	s.NoError(err)
 

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -943,8 +943,8 @@ func (wc *WorkflowClient) DescribeTaskList(ctx context.Context, taskList string,
 	return resp, nil
 }
 
-// CloseConnection closes underlying gRPC connection.
-func (wc *WorkflowClient) CloseConnection() {
+// Close client and clean up underlying resources.
+func (wc *WorkflowClient) Close() {
 	if wc.connectionCloser == nil {
 		return
 	}
@@ -1023,8 +1023,8 @@ func (nc *namespaceClient) Update(ctx context.Context, request *workflowservice.
 		}, createDynamicServiceRetryPolicy(ctx), isServiceTransientError)
 }
 
-// CloseConnection closes underlying gRPC connection.
-func (nc *namespaceClient) CloseConnection() {
+// Close client and clean up underlying resources.
+func (nc *namespaceClient) Close() {
 	if nc.connectionCloser == nil {
 		return
 	}

--- a/internal/worker.go
+++ b/internal/worker.go
@@ -134,7 +134,7 @@ type (
 		// default: BlockWorkflow, which just logs error but reply nothing back to server
 		NonDeterministicWorkflowPolicy WorkflowPanicPolicy
 
-		// Optional: worker graceful shutdown timeout
+		// Optional: worker graceful stop timeout
 		// default: 0s
 		WorkerStopTimeout time.Duration
 

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -518,8 +518,8 @@ func (_m *Client) TerminateWorkflow(ctx context.Context, workflowID string, runI
 	return r0
 }
 
-// CloseConnection provides a mock function without given fields
-func (_m *Client) CloseConnection() {
+// Close provides a mock function without given fields
+func (_m *Client) Close() {
 	ret := _m.Called()
 
 	if rf, ok := ret.Get(0).(func()); ok {

--- a/mocks/NamespaceClient.go
+++ b/mocks/NamespaceClient.go
@@ -89,8 +89,8 @@ func (_m *NamespaceClient) Update(ctx context.Context, request *workflowservice.
 	return r0
 }
 
-// CloseConnection provides a mock function without given fields
-func (_m *NamespaceClient) CloseConnection() {
+// Close provides a mock function without given fields
+func (_m *NamespaceClient) Close() {
 	ret := _m.Called()
 
 	if rf, ok := ret.Get(0).(func()); ok {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -115,9 +115,9 @@ func (ts *IntegrationTestSuite) SetupSuite() {
 
 func (ts *IntegrationTestSuite) TearDownSuite() {
 	ts.Assertions = require.New(ts.T())
-	ts.client.CloseConnection()
+	ts.client.Close()
 
-	// allow the pollers to shut down, and ensure there are no goroutine leaks.
+	// allow the pollers to stop, and ensure there are no goroutine leaks.
 	// this will wait for up to 1 minute for leaks to subside, but exit relatively quickly if possible.
 	max := time.After(time.Minute)
 	var last error
@@ -460,7 +460,7 @@ func (ts *IntegrationTestSuite) registerNamespace() {
 		Name:                                   name,
 		WorkflowExecutionRetentionPeriodInDays: retention,
 	})
-	client.CloseConnection()
+	client.Close()
 	if _, ok := err.(*serviceerror.NamespaceAlreadyExists); ok {
 		return
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -112,12 +112,12 @@ type (
 		// worker.RegisterActivityWithOptions(barActivity, RegisterActivityOptions{DisableAlreadyRegisteredCheck: true})
 		RegisterActivityWithOptions(a interface{}, options activity.RegisterOptions)
 
-		// Start starts the worker in a non-blocking fashion
+		// Start the worker in a non-blocking fashion.
 		Start() error
-		// Run is a blocking start and cleans up resources when killed
-		// returns error only if it fails to start the worker
+		// Run the worker in a blocking fashion. Stop the worker when process is killed with SIGINT or SIGTERM.
+		// Returns error only if worker fails to start.
 		Run() error
-		// Stop cleans up any resources opened by worker
+		// Stop the worker.
 		Stop()
 	}
 


### PR DESCRIPTION
1. Rename `CloseConnection` to `Close`,
2. Rename leftover `Shutdown` to `Stop`,
3. Fix comments.