### PR TITLE
Fixed unit test retry timeout

### DIFF
--- a/internal/session_test.go
+++ b/internal/session_test.go
@@ -609,6 +609,7 @@ func (s *SessionTestSuite) TestUserTimerWithinSession() {
 func (s *SessionTestSuite) TestActivityRetryWithinSession() {
 	workflowFn := func(ctx Context) error {
 		ao := ActivityOptions{
+			ScheduleToCloseTimeout: 10 * time.Minute,
 			ScheduleToStartTimeout: time.Minute,
 			StartToCloseTimeout:    time.Minute,
 			HeartbeatTimeout:       time.Second * 20,


### PR DESCRIPTION
Added missing ScheduleToCloseTimeout. Without it test takes very long.