### PR TITLE
Moved continueAsNewError to workflow

### DIFF
--- a/error.go
+++ b/error.go
@@ -29,9 +29,7 @@ import (
 
 	commonpb "go.temporal.io/temporal-proto/common"
 	"go.temporal.io/temporal-proto/serviceerror"
-
 	"go.temporal.io/temporal/internal"
-	"go.temporal.io/temporal/workflow"
 )
 
 /*
@@ -142,10 +140,6 @@ type (
 	// PanicError contains information about panicked workflow/activity.
 	PanicError = internal.PanicError
 
-	// ContinueAsNewError can be returned by a workflow implementation function and indicates that
-	// the workflow should continue as new with the same WorkflowID, but new RunID and new history.
-	ContinueAsNewError = internal.ContinueAsNewError
-
 	// UnknownExternalWorkflowExecutionError can be returned when external workflow doesn't exist
 	UnknownExternalWorkflowExecutionError = internal.UnknownExternalWorkflowExecutionError
 )
@@ -205,22 +199,6 @@ func IsTerminatedError(err error) bool {
 func IsPanicError(err error) bool {
 	var panicError *PanicError
 	return errors.As(err, &panicError)
-}
-
-// NewContinueAsNewError creates ContinueAsNewError instance
-// If the workflow main function returns this error then the current execution is ended and
-// the new execution with same workflow ID is started automatically with options
-// provided to this function.
-//  ctx - use context to override any options for the new workflow like execution timeout, decision task timeout, task list.
-//	  if not mentioned it would use the defaults that the current workflow is using.
-//        ctx := WithWorkflowExecutionTimeout(ctx, 30 * time.Minute)
-//        ctx := WithWorkflowTaskTimeout(ctx, time.Minute)
-//	  ctx := WithWorkflowTaskList(ctx, "example-group")
-//  wfn - workflow function. for new execution it can be different from the currently running.
-//  args - arguments for the new workflow.
-//
-func NewContinueAsNewError(ctx workflow.Context, wfn interface{}, args ...interface{}) *ContinueAsNewError {
-	return internal.NewContinueAsNewError(ctx, wfn, args...)
 }
 
 // NewTimeoutError creates TimeoutError instance.

--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -189,7 +189,7 @@ func (w *Workflows) ContinueAsNew(ctx workflow.Context, count int, taskList stri
 		return 999, nil
 	}
 	ctx = workflow.WithTaskList(ctx, taskList)
-	return -1, temporal.NewContinueAsNewError(ctx, w.ContinueAsNew, count-1, taskList)
+	return -1, workflow.NewContinueAsNewError(ctx, w.ContinueAsNew, count-1, taskList)
 }
 
 func (w *Workflows) ContinueAsNewWithOptions(ctx workflow.Context, count int, taskList string) (string, error) {
@@ -219,7 +219,7 @@ func (w *Workflows) ContinueAsNewWithOptions(ctx workflow.Context, count int, ta
 	}
 	ctx = workflow.WithTaskList(ctx, taskList)
 
-	return "", temporal.NewContinueAsNewError(ctx, w.ContinueAsNewWithOptions, count-1, taskList)
+	return "", workflow.NewContinueAsNewError(ctx, w.ContinueAsNewWithOptions, count-1, taskList)
 }
 
 func (w *Workflows) IDReusePolicy(

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -54,6 +54,10 @@ type (
 
 	// Info information about currently executing workflow
 	Info = internal.WorkflowInfo
+
+	// ContinueAsNewError can be returned by a workflow implementation function and indicates that
+	// the workflow should continue as new with the same WorkflowID, but new RunID and new history.
+	ContinueAsNewError = internal.ContinueAsNewError
 )
 
 // ExecuteActivity requests activity execution in the context of a workflow.
@@ -428,4 +432,20 @@ func GetLastCompletionResult(ctx Context, d ...interface{}) error {
 // This is only supported when using ElasticSearch.
 func UpsertSearchAttributes(ctx Context, attributes map[string]interface{}) error {
 	return internal.UpsertSearchAttributes(ctx, attributes)
+}
+
+// NewContinueAsNewError creates ContinueAsNewError instance
+// If the workflow main function returns this error then the current execution is ended and
+// the new execution with same workflow ID is started automatically with options
+// provided to this function.
+//  ctx - use context to override any options for the new workflow like execution timeout, decision task timeout, task list.
+//	  if not mentioned it would use the defaults that the current workflow is using.
+//        ctx := WithWorkflowExecutionTimeout(ctx, 30 * time.Minute)
+//        ctx := WithWorkflowTaskTimeout(ctx, time.Minute)
+//	  ctx := WithWorkflowTaskList(ctx, "example-group")
+//  wfn - workflow function. for new execution it can be different from the currently running.
+//  args - arguments for the new workflow.
+//
+func NewContinueAsNewError(ctx Context, wfn interface{}, args ...interface{}) *ContinueAsNewError {
+	return internal.NewContinueAsNewError(ctx, wfn, args...)
 }


### PR DESCRIPTION
Removed reference from temporal package to workflow. It is needed as RetryPolicy needs to be referenced from workflow package creating cycle.