### PR TITLE
Call cancel on context to prevent memory leak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ lint: $(ALL_SRC)
 		exit 1; \
 	fi
 
+vet: $(ALL_SRC)
+	go vet ./...
+
 staticcheck: $(ALL_SRC)
 	GO111MODULE=off go get -u honnef.co/go/tools/cmd/staticcheck
 	staticcheck ./...
@@ -114,4 +117,4 @@ fmt:
 clean:
 	rm -rf $(BUILD)
 
-check: lint errcheck staticcheck copyright bins
+check: lint vet errcheck staticcheck copyright bins

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -101,7 +101,8 @@ func (s *PollLayerInterfacesTestSuite) TearDownTest() {
 }
 
 func (s *PollLayerInterfacesTestSuite) TestProcessWorkflowTaskInterface() {
-	ctx, _ := context.WithTimeout(context.Background(), 10)
+	ctx, cancel := context.WithTimeout(context.Background(), 10)
+	defer cancel()
 
 	// mocks
 	s.service.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any()).Return(&workflowservice.PollForDecisionTaskResponse{}, nil)
@@ -121,7 +122,8 @@ func (s *PollLayerInterfacesTestSuite) TestProcessWorkflowTaskInterface() {
 }
 
 func (s *PollLayerInterfacesTestSuite) TestProcessActivityTaskInterface() {
-	ctx, _ := context.WithTimeout(context.Background(), 10)
+	ctx, cancel := context.WithTimeout(context.Background(), 10)
+	defer cancel()
 
 	// mocks
 	s.service.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any()).Return(&workflowservice.PollForActivityTaskResponse{}, nil)

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -522,6 +522,8 @@ func (lath *localActivityTaskHandler) executeLocalActivityTask(task *localActivi
 	}
 
 	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
 	task.Lock()
 	if task.canceled {
 		task.Unlock()


### PR DESCRIPTION
Run `go vet ./...` to detect possible context leaks.