### PR TITLE
Increase timeout values to prevent test flakiness

### DIFF
--- a/internal/common/backoff/retry_test.go
+++ b/internal/common/backoff/retry_test.go
@@ -58,27 +58,27 @@ func TestRetrySuccess(t *testing.T) {
 
 func TestNoRetryAfterContextDone(t *testing.T) {
 	t.Parallel()
-	i := 0
+	retryCounter := 0
 	op := func() error {
-		i++
+		retryCounter++
 
-		if i == 5 {
+		if retryCounter == 5 {
 			return nil
 		}
 
 		return &someError{}
 	}
 
-	policy := NewExponentialRetryPolicy(1 * time.Millisecond)
-	policy.SetMaximumInterval(5 * time.Millisecond)
+	policy := NewExponentialRetryPolicy(10 * time.Millisecond)
+	policy.SetMaximumInterval(50 * time.Millisecond)
 	policy.SetMaximumAttempts(10)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*5)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
 	err := Retry(ctx, op, policy, nil)
 	assert.Error(t, err)
-	assert.True(t, i >= 2) // verify that we did retry
+	assert.True(t, retryCounter >= 2, "retryCounter should be at least 2 but was %d", retryCounter) // verify that we did retry
 }
 
 func TestRetryFailed(t *testing.T) {


### PR DESCRIPTION
Test passes on my local machine but fails in CI/CD:

![image](https://user-images.githubusercontent.com/2232524/85166884-cb6d7c80-b21c-11ea-9be3-0787883e10d4.png)

Adding more time to prevent flakiness.