### PR TITLE
Add type argument to NewApplicationError constructor

### DIFF
--- a/error.go
+++ b/error.go
@@ -150,22 +150,26 @@ var (
 	ErrNoData = internal.ErrNoData
 )
 
-// NewApplicationError creates new instance of retryable *ApplicationError with message and optional details.
+// NewApplicationError creates new instance of retryable *ApplicationError with message, type, and optional details.
 // Use ApplicationError for any use case specific errors that cross activity and child workflow boundaries.
+// errType can be used to control if error is retryable or not. Add the same type in to RetryPolicy.NonRetryableErrorTypes
+// to avoid retrying of particular error types.
 func NewApplicationError(message, errType string, details ...interface{}) *ApplicationError {
 	return internal.NewApplicationError(message, errType, false, nil, details...)
 }
 
-// NewApplicationErrorWithCause creates new instance of retryable *ApplicationError with message, cause, and optional details.
+// NewApplicationErrorWithCause creates new instance of retryable *ApplicationError with message, type, cause, and optional details.
 // Use ApplicationError for any use case specific errors that cross activity and child workflow boundaries.
+// errType can be used to control if error is retryable or not. Add the same type in to RetryPolicy.NonRetryableErrorTypes
+// to avoid retrying of particular error types.
 func NewApplicationErrorWithCause(message, errType string, cause error, details ...interface{}) *ApplicationError {
 	return internal.NewApplicationError(message, errType, false, cause, details...)
 }
 
 // NewNonRetryableApplicationError creates new instance of non-retryable *ApplicationError with message, and optional cause and details.
 // Use ApplicationError for any use case specific errors that cross activity and child workflow boundaries.
-func NewNonRetryableApplicationError(message, errType string, cause error, details ...interface{}) *ApplicationError {
-	return internal.NewApplicationError(message, errType, true, cause, details...)
+func NewNonRetryableApplicationError(message, cause error, details ...interface{}) *ApplicationError {
+	return internal.NewApplicationError(message, "", true, cause, details...)
 }
 
 // NewCanceledError creates CanceledError instance.

--- a/error.go
+++ b/error.go
@@ -168,7 +168,7 @@ func NewApplicationErrorWithCause(message, errType string, cause error, details 
 
 // NewNonRetryableApplicationError creates new instance of non-retryable *ApplicationError with message, and optional cause and details.
 // Use ApplicationError for any use case specific errors that cross activity and child workflow boundaries.
-func NewNonRetryableApplicationError(message, cause error, details ...interface{}) *ApplicationError {
+func NewNonRetryableApplicationError(message string, cause error, details ...interface{}) *ApplicationError {
 	return internal.NewApplicationError(message, "", true, cause, details...)
 }
 

--- a/error.go
+++ b/error.go
@@ -70,7 +70,7 @@ if err != nil {
 		applicationErr.Details(&detailMsg) // extract strong typed details
 
 		// handle activity errors (errors created other than using NewApplicationError() API)
-		switch err.OriginalType() {
+		switch err.Type() {
 		case "CustomErrTypeA":
 			// handle CustomErrTypeA
 		case CustomErrTypeB:
@@ -145,25 +145,30 @@ type (
 	UnknownExternalWorkflowExecutionError = internal.UnknownExternalWorkflowExecutionError
 )
 
-// ErrNoData is returned when trying to extract strong typed data while there is no data available.
-var ErrNoData = internal.ErrNoData
+var (
+	// ErrNoData is returned when trying to extract strong typed data while there is no data available.
+	ErrNoData = internal.ErrNoData
+
+	// ApplicationErrorType is default error type for ApplicationError.
+	ApplicationErrorType = internal.ApplicationErrorType
+)
 
 // NewApplicationError creates new instance of retryable *ApplicationError with message and optional details.
 // Use ApplicationError for any use case specific errors that cross activity and child workflow boundaries.
-func NewApplicationError(message string, details ...interface{}) *ApplicationError {
-	return internal.NewApplicationError(message, false, nil, details...)
+func NewApplicationError(message, errType string, details ...interface{}) *ApplicationError {
+	return internal.NewApplicationError(message, errType, false, nil, details...)
 }
 
 // NewApplicationErrorWithCause creates new instance of retryable *ApplicationError with message, cause, and optional details.
 // Use ApplicationError for any use case specific errors that cross activity and child workflow boundaries.
-func NewApplicationErrorWithCause(message string, cause error, details ...interface{}) *ApplicationError {
-	return internal.NewApplicationError(message, false, cause, details...)
+func NewApplicationErrorWithCause(message, errType string, cause error, details ...interface{}) *ApplicationError {
+	return internal.NewApplicationError(message, errType, false, cause, details...)
 }
 
 // NewNonRetryableApplicationError creates new instance of non-retryable *ApplicationError with message, and optional cause and details.
 // Use ApplicationError for any use case specific errors that cross activity and child workflow boundaries.
-func NewNonRetryableApplicationError(message string, cause error, details ...interface{}) *ApplicationError {
-	return internal.NewApplicationError(message, true, cause, details...)
+func NewNonRetryableApplicationError(message, errType string, cause error, details ...interface{}) *ApplicationError {
+	return internal.NewApplicationError(message, errType, true, cause, details...)
 }
 
 // NewCanceledError creates CanceledError instance.

--- a/error.go
+++ b/error.go
@@ -148,9 +148,6 @@ type (
 var (
 	// ErrNoData is returned when trying to extract strong typed data while there is no data available.
 	ErrNoData = internal.ErrNoData
-
-	// ApplicationErrorType is default error type for ApplicationError.
-	ApplicationErrorType = internal.ApplicationErrorType
 )
 
 // NewApplicationError creates new instance of retryable *ApplicationError with message and optional details.

--- a/error.go
+++ b/error.go
@@ -166,10 +166,10 @@ func NewApplicationErrorWithCause(message, errType string, cause error, details 
 	return internal.NewApplicationError(message, errType, false, cause, details...)
 }
 
-// NewNonRetryableApplicationError creates new instance of non-retryable *ApplicationError with message, and optional cause and details.
+// NewNonRetryableApplicationError creates new instance of non-retryable *ApplicationError with message, type, and optional cause and details.
 // Use ApplicationError for any use case specific errors that cross activity and child workflow boundaries.
-func NewNonRetryableApplicationError(message string, cause error, details ...interface{}) *ApplicationError {
-	return internal.NewApplicationError(message, "", true, cause, details...)
+func NewNonRetryableApplicationError(message, errType string, cause error, details ...interface{}) *ApplicationError {
+	return internal.NewApplicationError(message, errType, true, cause, details...)
 }
 
 // NewCanceledError creates CanceledError instance.

--- a/internal/error.go
+++ b/internal/error.go
@@ -611,11 +611,7 @@ func IsRetryable(err error, nonRetryableTypes []string) bool {
 
 	var timeoutErr *TimeoutError
 	if errors.As(err, &timeoutErr) {
-		if timeoutErr.timeoutType != enumspb.TIMEOUT_TYPE_START_TO_CLOSE &&
-			timeoutErr.timeoutType != enumspb.TIMEOUT_TYPE_HEARTBEAT {
-			return false
-		}
-		return true
+		return timeoutErr.timeoutType == enumspb.TIMEOUT_TYPE_START_TO_CLOSE || timeoutErr.timeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT
 	}
 
 	var serverErr *ServerError
@@ -631,19 +627,7 @@ func IsRetryable(err error, nonRetryableTypes []string) bool {
 		}
 		errType = applicationErr.errType
 	} else {
-	ForLoop:
-		for {
-			switch err.(type) {
-			case *WorkflowExecutionError, *ChildWorkflowExecutionError, *ActivityError:
-				causeErr := errors.Unwrap(err)
-				if causeErr == nil {
-					break ForLoop
-				}
-				err = causeErr
-			default:
-				break ForLoop
-			}
-		}
+		// If it is generic Go error.
 		errType = getErrType(err)
 	}
 

--- a/internal/error.go
+++ b/internal/error.go
@@ -409,7 +409,9 @@ func (e *ApplicationError) Error() string {
 }
 
 // Type returns error type represented as string.
-// This type can be passed explicitly to ApplicationError constructor or will be set automatically for any other go errors.
+// This type can be passed explicitly to ApplicationError constructor.
+// Also any other Go error is converted to ApplicationError and type is set automatically using reflection.
+// For example instance of "MyCustomError struct" will be converted to ApplicationError and Type() will return "MyCustomError" string.
 func (e *ApplicationError) Type() string {
 	return e.errType
 }
@@ -612,11 +614,6 @@ func IsRetryable(err error, nonRetryableTypes []string) bool {
 	var timeoutErr *TimeoutError
 	if errors.As(err, &timeoutErr) {
 		return timeoutErr.timeoutType == enumspb.TIMEOUT_TYPE_START_TO_CLOSE || timeoutErr.timeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT
-	}
-
-	var serverErr *ServerError
-	if errors.As(err, &serverErr) {
-		return !serverErr.nonRetryable
 	}
 
 	var applicationErr *ApplicationError

--- a/internal/error.go
+++ b/internal/error.go
@@ -614,9 +614,8 @@ func IsRetryable(err error, nonRetryableTypes []string) bool {
 		if timeoutErr.timeoutType != enumspb.TIMEOUT_TYPE_START_TO_CLOSE &&
 			timeoutErr.timeoutType != enumspb.TIMEOUT_TYPE_HEARTBEAT {
 			return false
-		} else {
-			return true
 		}
+		return true
 	}
 
 	var serverErr *ServerError

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -554,16 +554,13 @@ func Test_IsRetryable(t *testing.T) {
 	require.False(IsRetryable(NewCanceledError(), nil))
 	require.False(IsRetryable(newWorkflowPanicError("", ""), nil))
 
-	require.False(IsRetryable(NewApplicationError("", "", true, nil), nil))
-	require.True(IsRetryable(NewApplicationError("", "", false, nil), nil))
-
 	require.True(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_START_TO_CLOSE, nil), nil))
 	require.False(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, nil), nil))
 	require.False(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, nil), nil))
 	require.True(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_HEARTBEAT, nil), nil))
 
-	require.False(IsRetryable(NewServerError("", true, nil), nil))
-	require.True(IsRetryable(NewServerError("", false, nil), nil))
+	require.False(IsRetryable(NewApplicationError("", "", true, nil), nil))
+	require.True(IsRetryable(NewApplicationError("", "", false, nil), nil))
 
 	applicationErr := NewApplicationError("", "MyCoolErr", false, nil)
 	require.True(IsRetryable(applicationErr, nil))

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -166,12 +166,12 @@ func Test_ApplicationError(t *testing.T) {
 	var a1 string
 	var a2 int
 	var a3 testStruct
-	err0 := NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, testErrorDetails1)
+	err0 := NewApplicationError(applicationErrReasonA, "", false, nil, testErrorDetails1)
 	require.True(t, err0.HasDetails())
 	_ = err0.Details(&a1)
 	require.Equal(t, testErrorDetails1, a1)
 	a1 = ""
-	err0 = NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, testErrorDetails1, testErrorDetails2, testErrorDetails3)
+	err0 = NewApplicationError(applicationErrReasonA, "", false, nil, testErrorDetails1, testErrorDetails2, testErrorDetails3)
 	require.True(t, err0.HasDetails())
 	_ = err0.Details(&a1, &a2, &a3)
 	require.Equal(t, testErrorDetails1, a1)
@@ -200,11 +200,11 @@ func Test_ApplicationError(t *testing.T) {
 
 	// test reason and no detail
 	newReason := "another reason"
-	err2 := NewApplicationError(newReason, ApplicationErrorType, false, nil)
+	err2 := NewApplicationError(newReason, "", false, nil)
 	require.True(t, !err2.HasDetails())
 	require.Equal(t, ErrNoData, err2.Details())
 	require.Equal(t, newReason, err2.Error())
-	err3 := NewApplicationError(newReason, ApplicationErrorType, false, nil, nil)
+	err3 := NewApplicationError(newReason, "", false, nil, nil)
 	// TODO: probably we want to handle this case when details are nil, HasDetails return false
 	require.True(t, err3.HasDetails())
 
@@ -228,14 +228,14 @@ func Test_ApplicationError(t *testing.T) {
 
 func Test_ApplicationError_Pointer(t *testing.T) {
 	a1 := testStruct2{}
-	err1 := NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, testErrorDetails4)
+	err1 := NewApplicationError(applicationErrReasonA, "", false, nil, testErrorDetails4)
 	require.True(t, err1.HasDetails())
 	err := err1.Details(&a1)
 	require.NoError(t, err)
 	require.Equal(t, testErrorDetails4, a1)
 
 	a2 := &testStruct2{}
-	err2 := NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, &testErrorDetails4) // // pointer in details
+	err2 := NewApplicationError(applicationErrReasonA, "", false, nil, &testErrorDetails4) // // pointer in details
 	require.True(t, err2.HasDetails())
 	err = err2.Details(&a2)
 	require.NoError(t, err)
@@ -649,7 +649,7 @@ func Test_convertErrorToFailure_ServerError(t *testing.T) {
 func Test_convertErrorToFailure_ActivityError(t *testing.T) {
 	require := require.New(t)
 
-	applicationErr := NewApplicationError("app err", ApplicationErrorType, true, nil)
+	applicationErr := NewApplicationError("app err", "", true, nil)
 	err := NewActivityError(8, 22, "alex", &commonpb.ActivityType{Name: "activityType"}, "32283", enumspb.RETRY_STATUS_NON_RETRYABLE_FAILURE, applicationErr)
 	f := convertErrorToFailure(err, DefaultDataConverter)
 	require.Equal("activity task error (scheduledEventID: 8, startedEventID: 22, identity: alex): app err", f.GetMessage())
@@ -676,7 +676,7 @@ func Test_convertErrorToFailure_ActivityError(t *testing.T) {
 func Test_convertErrorToFailure_ChildWorkflowExecutionError(t *testing.T) {
 	require := require.New(t)
 
-	applicationErr := NewApplicationError("app err", ApplicationErrorType, true, nil)
+	applicationErr := NewApplicationError("app err", "", true, nil)
 	err := NewChildWorkflowExecutionError("namespace", "wID", "rID", "wfType", 8, 22, enumspb.RETRY_STATUS_NON_RETRYABLE_FAILURE, applicationErr)
 	f := convertErrorToFailure(err, DefaultDataConverter)
 	require.Equal("child workflow execution error (workflowID: wID, runID: rID, initiatedEventID: 8, startedEventID: 22, workflowType: wfType): app err", f.GetMessage())

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -166,12 +166,12 @@ func Test_ApplicationError(t *testing.T) {
 	var a1 string
 	var a2 int
 	var a3 testStruct
-	err0 := NewApplicationError(applicationErrReasonA, false, nil, testErrorDetails1)
+	err0 := NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, testErrorDetails1)
 	require.True(t, err0.HasDetails())
 	_ = err0.Details(&a1)
 	require.Equal(t, testErrorDetails1, a1)
 	a1 = ""
-	err0 = NewApplicationError(applicationErrReasonA, false, nil, testErrorDetails1, testErrorDetails2, testErrorDetails3)
+	err0 = NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, testErrorDetails1, testErrorDetails2, testErrorDetails3)
 	require.True(t, err0.HasDetails())
 	_ = err0.Details(&a1, &a2, &a3)
 	require.Equal(t, testErrorDetails1, a1)
@@ -200,11 +200,11 @@ func Test_ApplicationError(t *testing.T) {
 
 	// test reason and no detail
 	newReason := "another reason"
-	err2 := NewApplicationError(newReason, false, nil)
+	err2 := NewApplicationError(newReason, ApplicationErrorType, false, nil)
 	require.True(t, !err2.HasDetails())
 	require.Equal(t, ErrNoData, err2.Details())
 	require.Equal(t, newReason, err2.Error())
-	err3 := NewApplicationError(newReason, false, nil, nil)
+	err3 := NewApplicationError(newReason, ApplicationErrorType, false, nil, nil)
 	// TODO: probably we want to handle this case when details are nil, HasDetails return false
 	require.True(t, err3.HasDetails())
 
@@ -228,14 +228,14 @@ func Test_ApplicationError(t *testing.T) {
 
 func Test_ApplicationError_Pointer(t *testing.T) {
 	a1 := testStruct2{}
-	err1 := NewApplicationError(applicationErrReasonA, false, nil, testErrorDetails4)
+	err1 := NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, testErrorDetails4)
 	require.True(t, err1.HasDetails())
 	err := err1.Details(&a1)
 	require.NoError(t, err)
 	require.Equal(t, testErrorDetails4, a1)
 
 	a2 := &testStruct2{}
-	err2 := NewApplicationError(applicationErrReasonA, false, nil, &testErrorDetails4) // // pointer in details
+	err2 := NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, &testErrorDetails4) // // pointer in details
 	require.True(t, err2.HasDetails())
 	err = err2.Details(&a2)
 	require.NoError(t, err)
@@ -480,32 +480,24 @@ func Test_ContinueAsNewError(t *testing.T) {
 	require.Equal(t, header, continueAsNewErr.params.Header)
 }
 
-func Test_GetErrorType(t *testing.T) {
-	require := require.New(t)
-	err := errors.New("some error")
-	errType := getErrorType(err)
-	require.Equal("errorString", errType)
-
-	err = NewApplicationError("application error", false, nil)
-	errType = getErrorType(err)
-	require.Equal("ApplicationError", errType)
-}
-
 type coolError struct{}
 
 func (e coolError) Error() string {
 	return "cool error"
 }
 
-func Test_GetErrorTypePointer(t *testing.T) {
+func Test_GetErrorType(t *testing.T) {
 	require := require.New(t)
+	err := errors.New("some error")
+	errType := getErrType(err)
+	require.Equal("errorString", errType)
 
-	err := coolError{}
-	errType := getErrorType(err)
+	err = coolError{}
+	errType = getErrType(err)
 	require.Equal("coolError", errType)
 
 	err2 := &coolError{}
-	errType2 := getErrorType(err2)
+	errType2 := getErrType(err2)
 	require.Equal("coolError", errType2)
 }
 
@@ -515,8 +507,8 @@ func Test_IsRetryable(t *testing.T) {
 	require.False(IsRetryable(NewCanceledError(), []string{}))
 	require.False(IsRetryable(newWorkflowPanicError("", ""), []string{}))
 
-	require.False(IsRetryable(NewApplicationError("", true, nil), []string{}))
-	require.True(IsRetryable(NewApplicationError("", false, nil), []string{}))
+	require.False(IsRetryable(NewApplicationError("", "", true, nil), []string{}))
+	require.True(IsRetryable(NewApplicationError("", "", false, nil), []string{}))
 
 	require.True(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_START_TO_CLOSE, nil), []string{}))
 	require.False(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, nil), []string{}))
@@ -526,7 +518,7 @@ func Test_IsRetryable(t *testing.T) {
 	require.False(IsRetryable(NewServerError("", true, nil), []string{}))
 	require.True(IsRetryable(NewServerError("", false, nil), []string{}))
 
-	applicationErr := &ApplicationError{originalType: "MyCoolErr"}
+	applicationErr := NewApplicationError("", "MyCoolErr", false, nil)
 	require.True(IsRetryable(applicationErr, []string{}))
 	require.False(IsRetryable(applicationErr, []string{"MyCoolErr"}))
 
@@ -542,10 +534,10 @@ func Test_IsRetryable(t *testing.T) {
 func Test_convertErrorToFailure_ApplicationError(t *testing.T) {
 	require := require.New(t)
 
-	err := NewApplicationError("message", true, errors.New("cause error"), "details", 2208)
+	err := NewApplicationError("message", "customType", true, errors.New("cause error"), "details", 2208)
 	f := convertErrorToFailure(err, DefaultDataConverter)
 	require.Equal("message", f.GetMessage())
-	require.Equal("ApplicationError", f.GetApplicationFailureInfo().GetType())
+	require.Equal("customType", f.GetApplicationFailureInfo().GetType())
 	require.Equal(true, f.GetApplicationFailureInfo().GetNonRetryable())
 	require.Equal([]byte(`"details"`), f.GetApplicationFailureInfo().GetDetails().GetPayloads()[0].GetData())
 	require.Equal([]byte(`2208`), f.GetApplicationFailureInfo().GetDetails().GetPayloads()[1].GetData())
@@ -657,7 +649,7 @@ func Test_convertErrorToFailure_ServerError(t *testing.T) {
 func Test_convertErrorToFailure_ActivityError(t *testing.T) {
 	require := require.New(t)
 
-	applicationErr := NewApplicationError("app err", true, nil)
+	applicationErr := NewApplicationError("app err", ApplicationErrorType, true, nil)
 	err := NewActivityError(8, 22, "alex", &commonpb.ActivityType{Name: "activityType"}, "32283", enumspb.RETRY_STATUS_NON_RETRYABLE_FAILURE, applicationErr)
 	f := convertErrorToFailure(err, DefaultDataConverter)
 	require.Equal("activity task error (scheduledEventID: 8, startedEventID: 22, identity: alex): app err", f.GetMessage())
@@ -684,7 +676,7 @@ func Test_convertErrorToFailure_ActivityError(t *testing.T) {
 func Test_convertErrorToFailure_ChildWorkflowExecutionError(t *testing.T) {
 	require := require.New(t)
 
-	applicationErr := NewApplicationError("app err", true, nil)
+	applicationErr := NewApplicationError("app err", ApplicationErrorType, true, nil)
 	err := NewChildWorkflowExecutionError("namespace", "wID", "rID", "wfType", 8, 22, enumspb.RETRY_STATUS_NON_RETRYABLE_FAILURE, applicationErr)
 	f := convertErrorToFailure(err, DefaultDataConverter)
 	require.Equal("child workflow execution error (workflowID: wID, runID: rID, initiatedEventID: 8, startedEventID: 22, workflowType: wfType): app err", f.GetMessage())
@@ -714,12 +706,12 @@ func Test_convertErrorToFailure_UnknowError(t *testing.T) {
 	var coolErr *ApplicationError
 	require.True(errors.As(err2, &coolErr))
 	require.Equal(err.Error(), coolErr.Error())
-	require.Equal("coolError", coolErr.OriginalType())
+	require.Equal("coolError", coolErr.Type())
 }
 
 func Test_convertErrorToFailure_SavedFailure(t *testing.T) {
 	require := require.New(t)
-	err := NewApplicationError("message that will be ignored", false, nil)
+	err := NewApplicationError("message that will be ignored", "type nobody cares", false, nil)
 	err.originalFailure = &failurepb.Failure{
 		Message:    "actual message",
 		StackTrace: "some stack trace",
@@ -745,7 +737,7 @@ func Test_convertFailureToError_ApplicationFailure(t *testing.T) {
 	f := &failurepb.Failure{
 		Message: "message",
 		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-			Type:         "ApplicationError",
+			Type:         "MyCoolType",
 			NonRetryable: true,
 			Details:      details,
 		}},
@@ -762,7 +754,7 @@ func Test_convertFailureToError_ApplicationFailure(t *testing.T) {
 	var applicationErr *ApplicationError
 	require.True(errors.As(err, &applicationErr))
 	require.Equal("message", applicationErr.Error())
-	require.Equal("ApplicationError", applicationErr.OriginalType())
+	require.Equal("MyCoolType", applicationErr.Type())
 	require.Equal(true, applicationErr.NonRetryable())
 	var str string
 	var n int
@@ -773,7 +765,7 @@ func Test_convertFailureToError_ApplicationFailure(t *testing.T) {
 	err = errors.Unwrap(err)
 	require.True(errors.As(err, &applicationErr))
 	require.Equal("cause message", applicationErr.Error())
-	require.Equal("UnknownType", applicationErr.OriginalType())
+	require.Equal("UnknownType", applicationErr.Type())
 	require.Equal(false, applicationErr.NonRetryable())
 
 	f = &failurepb.Failure{
@@ -802,7 +794,7 @@ func Test_convertFailureToError_ApplicationFailure(t *testing.T) {
 	var coolErr *ApplicationError
 	require.True(errors.As(err, &coolErr))
 	require.Equal("message", coolErr.Error())
-	require.Equal("CoolError", coolErr.OriginalType())
+	require.Equal("CoolError", coolErr.Type())
 	require.Equal(false, coolErr.NonRetryable())
 }
 
@@ -889,7 +881,7 @@ func Test_convertFailureToError_SaveFailure(t *testing.T) {
 	require.True(errors.As(err, &applicationErr))
 	require.NotNil(applicationErr.originalFailure)
 	applicationErr.message = "errors are immutable, message can't be changed"
-	applicationErr.originalType = "ApplicationError (is ignored)"
+	applicationErr.errType = "ApplicationError (is ignored)"
 	applicationErr.nonRetryable = false
 
 	var activityErr *ActivityError

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -503,32 +503,30 @@ func Test_GetErrorType(t *testing.T) {
 
 func Test_IsRetryable(t *testing.T) {
 	require := require.New(t)
-	require.False(IsRetryable(newTerminatedError(), []string{}))
-	require.False(IsRetryable(NewCanceledError(), []string{}))
-	require.False(IsRetryable(newWorkflowPanicError("", ""), []string{}))
+	require.False(IsRetryable(newTerminatedError(), nil))
+	require.False(IsRetryable(NewCanceledError(), nil))
+	require.False(IsRetryable(newWorkflowPanicError("", ""), nil))
 
-	require.False(IsRetryable(NewApplicationError("", "", true, nil), []string{}))
-	require.True(IsRetryable(NewApplicationError("", "", false, nil), []string{}))
+	require.False(IsRetryable(NewApplicationError("", "", true, nil), nil))
+	require.True(IsRetryable(NewApplicationError("", "", false, nil), nil))
 
-	require.True(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_START_TO_CLOSE, nil), []string{}))
-	require.False(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, nil), []string{}))
-	require.False(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, nil), []string{}))
-	require.True(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_HEARTBEAT, nil), []string{}))
+	require.True(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_START_TO_CLOSE, nil), nil))
+	require.False(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, nil), nil))
+	require.False(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, nil), nil))
+	require.True(IsRetryable(NewTimeoutError(enumspb.TIMEOUT_TYPE_HEARTBEAT, nil), nil))
 
-	require.False(IsRetryable(NewServerError("", true, nil), []string{}))
-	require.True(IsRetryable(NewServerError("", false, nil), []string{}))
+	require.False(IsRetryable(NewServerError("", true, nil), nil))
+	require.True(IsRetryable(NewServerError("", false, nil), nil))
 
 	applicationErr := NewApplicationError("", "MyCoolErr", false, nil)
-	require.True(IsRetryable(applicationErr, []string{}))
+	require.True(IsRetryable(applicationErr, nil))
 	require.False(IsRetryable(applicationErr, []string{"MyCoolErr"}))
 
 	coolErr := &coolError{}
-	require.True(IsRetryable(coolErr, []string{}))
+	require.True(IsRetryable(coolErr, nil))
 	require.False(IsRetryable(coolErr, []string{"coolError"}))
-
-	workflowExecutionErr := NewWorkflowExecutionError("", "", "", NewActivityError(0, 0, "", nil, "", enumspb.RETRY_STATUS_NON_RETRYABLE_FAILURE, coolErr))
-	require.True(IsRetryable(workflowExecutionErr, []string{}))
-	require.False(IsRetryable(workflowExecutionErr, []string{"coolError"}))
+	require.True(IsRetryable(coolErr, []string{"anotherError"}))
+	require.False(IsRetryable(coolErr, []string{"anotherError", "coolError"}))
 }
 
 func Test_convertErrorToFailure_ApplicationError(t *testing.T) {

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -931,7 +931,7 @@ ProcessEvents:
 		switch w.wth.workflowPanicPolicy {
 		case FailWorkflow:
 			// complete workflow with custom error will fail the workflow
-			eventHandler.Complete(nil, NewApplicationError("FailWorkflow", false, nonDeterministicErr))
+			eventHandler.Complete(nil, NewApplicationError("Non-determimistic error cause workflow to fail due to FailWorkflow workflow panic policy.", ApplicationErrorType, false, nonDeterministicErr))
 		case BlockWorkflow:
 			// return error here will be convert to DecisionTaskFailed for the first time, and ignored for subsequent
 			// attempts which will cause DecisionTaskTimeout and server will retry forever until issue got fixed or

--- a/internal/internal_task_handlers.go
+++ b/internal/internal_task_handlers.go
@@ -931,7 +931,7 @@ ProcessEvents:
 		switch w.wth.workflowPanicPolicy {
 		case FailWorkflow:
 			// complete workflow with custom error will fail the workflow
-			eventHandler.Complete(nil, NewApplicationError("Non-determimistic error cause workflow to fail due to FailWorkflow workflow panic policy.", ApplicationErrorType, false, nonDeterministicErr))
+			eventHandler.Complete(nil, NewApplicationError("Non-determimistic error cause workflow to fail due to FailWorkflow workflow panic policy.", "", false, nonDeterministicErr))
 		case BlockWorkflow:
 			// return error here will be convert to DecisionTaskFailed for the first time, and ignored for subsequent
 			// attempts which will cause DecisionTaskTimeout and server will retry forever until issue got fixed or

--- a/internal/internal_task_handlers_interfaces_test.go
+++ b/internal/internal_task_handlers_interfaces_test.go
@@ -75,7 +75,7 @@ func (ath sampleActivityTaskHandler) Execute(_ string, task *workflowservice.Pol
 	activityImplementation := &greeterActivity{}
 	result, err := activityImplementation.Execute(context.Background(), task.Input)
 	if err != nil {
-		failure := convertErrorToFailure(NewApplicationError(err.Error(), false, nil), getDefaultDataConverter())
+		failure := convertErrorToFailure(NewApplicationError(err.Error(), getErrType(err), false, nil), getDefaultDataConverter())
 		return &workflowservice.RespondActivityTaskFailedRequest{
 			TaskToken: task.TaskToken,
 			Failure:   failure,

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -572,7 +572,7 @@ WaitResult:
 			return &localActivityResult{err: ErrDeadlineExceeded, task: task}
 		} else {
 			// should not happen
-			return &localActivityResult{err: NewApplicationError("unexpected context done", true, nil), task: task}
+			return &localActivityResult{err: NewApplicationError("unexpected context done", ApplicationErrorType, true, nil), task: task}
 		}
 	case <-doneCh:
 		// local activity completed

--- a/internal/internal_task_pollers.go
+++ b/internal/internal_task_pollers.go
@@ -572,7 +572,7 @@ WaitResult:
 			return &localActivityResult{err: ErrDeadlineExceeded, task: task}
 		} else {
 			// should not happen
-			return &localActivityResult{err: NewApplicationError("unexpected context done", ApplicationErrorType, true, nil), task: task}
+			return &localActivityResult{err: NewApplicationError("unexpected context done", "", true, nil), task: task}
 		}
 	case <-doneCh:
 		// local activity completed

--- a/internal/internal_utils_test.go
+++ b/internal/internal_utils_test.go
@@ -85,12 +85,12 @@ func TestConvertFailureToError_ApplicationError(t *testing.T) {
 	require.NoError(t, err)
 
 	val := newEncodedValues(details, dc).(*EncodedValues)
-	applicationErr1 := NewApplicationError(applicationErrReasonA, false, nil, val)
+	applicationErr1 := NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, val)
 	failure := convertErrorToFailure(applicationErr1, dc)
 	require.Equal(t, applicationErrReasonA, failure.GetMessage())
 	require.Equal(t, val.values, failure.GetApplicationFailureInfo().GetDetails())
 
-	applicationErr2 := NewApplicationError(applicationErrReasonA, false, nil, testErrorDetails1)
+	applicationErr2 := NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, testErrorDetails1)
 	val2, err := encodeArgs(dc, []interface{}{testErrorDetails1})
 	require.NoError(t, err)
 	failure = convertErrorToFailure(applicationErr2, dc)

--- a/internal/internal_utils_test.go
+++ b/internal/internal_utils_test.go
@@ -85,12 +85,12 @@ func TestConvertFailureToError_ApplicationError(t *testing.T) {
 	require.NoError(t, err)
 
 	val := newEncodedValues(details, dc).(*EncodedValues)
-	applicationErr1 := NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, val)
+	applicationErr1 := NewApplicationError(applicationErrReasonA, "", false, nil, val)
 	failure := convertErrorToFailure(applicationErr1, dc)
 	require.Equal(t, applicationErrReasonA, failure.GetMessage())
 	require.Equal(t, val.values, failure.GetApplicationFailureInfo().GetDetails())
 
-	applicationErr2 := NewApplicationError(applicationErrReasonA, ApplicationErrorType, false, nil, testErrorDetails1)
+	applicationErr2 := NewApplicationError(applicationErrReasonA, "", false, nil, testErrorDetails1)
 	val2, err := encodeArgs(dc, []interface{}{testErrorDetails1})
 	require.NoError(t, err)
 	failure = convertErrorToFailure(applicationErr2, dc)

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1519,7 +1519,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 	a1 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (err error) {
-			return NewApplicationError("testReason", false, nil, "testStringDetails")
+			return NewApplicationError("testReason", ApplicationErrorType, false, nil, "testStringDetails")
 		}}
 	_, e := a1.Execute(ctx, testEncodeFunctionArgs(dataConverter, 1))
 	require.Error(t, e)
@@ -1532,7 +1532,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 	a2 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (err error) {
-			return NewApplicationError("testReason", false, nil, testErrorDetails{T: "testErrorStack"})
+			return NewApplicationError("testReason", ApplicationErrorType, false, nil, testErrorDetails{T: "testErrorStack"})
 		}}
 	_, e = a2.Execute(ctx, testEncodeFunctionArgs(dataConverter, 1))
 	require.Error(t, e)
@@ -1545,7 +1545,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 	a3 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (result string, err error) {
-			return "testResult", NewApplicationError("testReason", false, nil, testErrorDetails{T: "testErrorStack3"})
+			return "testResult", NewApplicationError("testReason", ApplicationErrorType, false, nil, testErrorDetails{T: "testErrorStack3"})
 		}}
 	encResult, e := a3.Execute(ctx, testEncodeFunctionArgs(dataConverter, 1))
 	var result string
@@ -1561,7 +1561,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 	a4 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (result string, err error) {
-			return "testResult4", NewApplicationError("testReason", false, nil, "testMultipleString", testErrorDetails{T: "testErrorStack4"})
+			return "testResult4", NewApplicationError("testReason", ApplicationErrorType, false, nil, "testMultipleString", testErrorDetails{T: "testErrorStack4"})
 		}}
 	encResult, e = a4.Execute(ctx, testEncodeFunctionArgs(dataConverter, 1))
 	err = dataConverter.FromPayloads(encResult, &result)

--- a/internal/internal_worker_test.go
+++ b/internal/internal_worker_test.go
@@ -1519,7 +1519,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 	a1 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (err error) {
-			return NewApplicationError("testReason", ApplicationErrorType, false, nil, "testStringDetails")
+			return NewApplicationError("testReason", "", false, nil, "testStringDetails")
 		}}
 	_, e := a1.Execute(ctx, testEncodeFunctionArgs(dataConverter, 1))
 	require.Error(t, e)
@@ -1532,7 +1532,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 	a2 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (err error) {
-			return NewApplicationError("testReason", ApplicationErrorType, false, nil, testErrorDetails{T: "testErrorStack"})
+			return NewApplicationError("testReason", "", false, nil, testErrorDetails{T: "testErrorStack"})
 		}}
 	_, e = a2.Execute(ctx, testEncodeFunctionArgs(dataConverter, 1))
 	require.Error(t, e)
@@ -1545,7 +1545,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 	a3 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (result string, err error) {
-			return "testResult", NewApplicationError("testReason", ApplicationErrorType, false, nil, testErrorDetails{T: "testErrorStack3"})
+			return "testResult", NewApplicationError("testReason", "", false, nil, testErrorDetails{T: "testErrorStack3"})
 		}}
 	encResult, e := a3.Execute(ctx, testEncodeFunctionArgs(dataConverter, 1))
 	var result string
@@ -1561,7 +1561,7 @@ func testActivityErrorWithDetailsHelper(ctx context.Context, t *testing.T, dataC
 	a4 := activityExecutor{
 		name: "test",
 		fn: func(arg1 int) (result string, err error) {
-			return "testResult4", NewApplicationError("testReason", ApplicationErrorType, false, nil, "testMultipleString", testErrorDetails{T: "testErrorStack4"})
+			return "testResult4", NewApplicationError("testReason", "", false, nil, "testMultipleString", testErrorDetails{T: "testErrorStack4"})
 		}}
 	encResult, e = a4.Execute(ctx, testEncodeFunctionArgs(dataConverter, 1))
 	err = dataConverter.FromPayloads(encResult, &result)

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -713,7 +713,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Failed() {
 	eventType := enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED
 	reason := "some reason"
 	details := "some details"
-	applicationError := NewApplicationError(reason, ApplicationErrorType, false, nil, details)
+	applicationError := NewApplicationError(reason, "", false, nil, details)
 	failure := convertErrorToFailure(applicationError, getDefaultDataConverter())
 
 	getRequest := getGetWorkflowExecutionHistoryRequest(filterType)

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -713,7 +713,7 @@ func (s *workflowRunSuite) TestExecuteWorkflow_NoDup_Failed() {
 	eventType := enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED
 	reason := "some reason"
 	details := "some details"
-	applicationError := NewApplicationError(reason, false, nil, details)
+	applicationError := NewApplicationError(reason, ApplicationErrorType, false, nil, details)
 	failure := convertErrorToFailure(applicationError, getDefaultDataConverter())
 
 	getRequest := getGetWorkflowExecutionHistoryRequest(filterType)

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2239,7 +2239,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityRetry() {
 	attempt1Count := 0
 	activityFailedFn := func(ctx context.Context) (string, error) {
 		attempt1Count++
-		return "", NewApplicationError("bad-bug", ApplicationErrorType, true, nil)
+		return "", NewApplicationError("bad-bug", "", true, nil)
 	}
 
 	attempt2Count := 0
@@ -2247,7 +2247,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityRetry() {
 		attempt2Count++
 		info := GetActivityInfo(ctx)
 		if info.Attempt < 2 {
-			return "", NewApplicationError("bad-luck", ApplicationErrorType, false, nil)
+			return "", NewApplicationError("bad-luck", "", false, nil)
 		}
 		return "retry-done", nil
 	}
@@ -2315,7 +2315,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityHeartbeatRetry() {
 			// process task i
 			RecordActivityHeartbeat(ctx, i)
 			if j == 2 && i < firstTaskID+taskCount-1 { // simulate failure after processing 3 tasks
-				return NewApplicationError("bad-luck", ApplicationErrorType, false, nil)
+				return NewApplicationError("bad-luck", "", false, nil)
 			}
 		}
 
@@ -2360,7 +2360,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_LocalActivityRetry() {
 	localActivityFn := func(ctx context.Context) (int32, error) {
 		info := GetActivityInfo(ctx)
 		if info.Attempt < 2 {
-			return int32(-1), NewApplicationError("bad-luck", ApplicationErrorType, false, nil)
+			return int32(-1), NewApplicationError("bad-luck", "", false, nil)
 		}
 		return info.Attempt, nil
 	}
@@ -2478,7 +2478,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflowRetry() {
 	childWorkflowFn := func(ctx Context) (string, error) {
 		info := GetWorkflowInfo(ctx)
 		if info.Attempt < 2 {
-			return "", NewApplicationError("bad-luck", ApplicationErrorType, false, nil)
+			return "", NewApplicationError("bad-luck", "", false, nil)
 		}
 		return "retry-done", nil
 	}
@@ -2520,7 +2520,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_SignalChildWorkflowRetry() {
 	childWorkflowFn := func(ctx Context) (string, error) {
 		info := GetWorkflowInfo(ctx)
 		if info.Attempt < 2 {
-			return "", NewApplicationError("bad-luck", ApplicationErrorType, false, nil)
+			return "", NewApplicationError("bad-luck", "", false, nil)
 		}
 
 		ch := GetSignalChannel(ctx, "test-signal-name")

--- a/internal/internal_workflow_testsuite_test.go
+++ b/internal/internal_workflow_testsuite_test.go
@@ -2239,7 +2239,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityRetry() {
 	attempt1Count := 0
 	activityFailedFn := func(ctx context.Context) (string, error) {
 		attempt1Count++
-		return "", NewApplicationError("bad-bug", true, nil)
+		return "", NewApplicationError("bad-bug", ApplicationErrorType, true, nil)
 	}
 
 	attempt2Count := 0
@@ -2247,7 +2247,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityRetry() {
 		attempt2Count++
 		info := GetActivityInfo(ctx)
 		if info.Attempt < 2 {
-			return "", NewApplicationError("bad-luck", false, nil)
+			return "", NewApplicationError("bad-luck", ApplicationErrorType, false, nil)
 		}
 		return "retry-done", nil
 	}
@@ -2315,7 +2315,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ActivityHeartbeatRetry() {
 			// process task i
 			RecordActivityHeartbeat(ctx, i)
 			if j == 2 && i < firstTaskID+taskCount-1 { // simulate failure after processing 3 tasks
-				return NewApplicationError("bad-luck", false, nil)
+				return NewApplicationError("bad-luck", ApplicationErrorType, false, nil)
 			}
 		}
 
@@ -2360,7 +2360,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_LocalActivityRetry() {
 	localActivityFn := func(ctx context.Context) (int32, error) {
 		info := GetActivityInfo(ctx)
 		if info.Attempt < 2 {
-			return int32(-1), NewApplicationError("bad-luck", false, nil)
+			return int32(-1), NewApplicationError("bad-luck", ApplicationErrorType, false, nil)
 		}
 		return info.Attempt, nil
 	}
@@ -2478,7 +2478,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_ChildWorkflowRetry() {
 	childWorkflowFn := func(ctx Context) (string, error) {
 		info := GetWorkflowInfo(ctx)
 		if info.Attempt < 2 {
-			return "", NewApplicationError("bad-luck", false, nil)
+			return "", NewApplicationError("bad-luck", ApplicationErrorType, false, nil)
 		}
 		return "retry-done", nil
 	}
@@ -2520,7 +2520,7 @@ func (s *WorkflowTestSuiteUnitTest) Test_SignalChildWorkflowRetry() {
 	childWorkflowFn := func(ctx Context) (string, error) {
 		info := GetWorkflowInfo(ctx)
 		if info.Attempt < 2 {
-			return "", NewApplicationError("bad-luck", false, nil)
+			return "", NewApplicationError("bad-luck", ApplicationErrorType, false, nil)
 		}
 
 		ch := GetSignalChannel(ctx, "test-signal-name")

--- a/internal/session.go
+++ b/internal/session.go
@@ -495,7 +495,7 @@ func newSessionEnvironment(resourceID string, concurrentSessionExecutionSize int
 
 func (env *sessionEnvironmentImpl) CreateSession(_ context.Context, sessionID string) (<-chan struct{}, error) {
 	if !env.sessionTokenBucket.getToken() {
-		return nil, NewApplicationError(errTooManySessionsMsg, true, nil)
+		return nil, NewApplicationError(errTooManySessionsMsg, ApplicationErrorType, true, nil)
 	}
 
 	env.Lock()

--- a/internal/session.go
+++ b/internal/session.go
@@ -495,7 +495,7 @@ func newSessionEnvironment(resourceID string, concurrentSessionExecutionSize int
 
 func (env *sessionEnvironmentImpl) CreateSession(_ context.Context, sessionID string) (<-chan struct{}, error) {
 	if !env.sessionTokenBucket.getToken() {
-		return nil, NewApplicationError(errTooManySessionsMsg, ApplicationErrorType, true, nil)
+		return nil, NewApplicationError(errTooManySessionsMsg, "", true, nil)
 	}
 
 	env.Lock()

--- a/internal/workflow.go
+++ b/internal/workflow.go
@@ -159,7 +159,7 @@ type (
 		RunID string
 	}
 
-	// EncodedValue is type alias used to encapsulate/extract encoded result from workflow/activity.
+	// EncodedValue is type used to encapsulate/extract encoded result from workflow/activity.
 	EncodedValue struct {
 		value         *commonpb.Payloads
 		dataConverter DataConverter

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -46,7 +46,7 @@ type Activities2 struct {
 	impl *Activities
 }
 
-var errFailOnPurpose = temporal.NewApplicationError("failing on purpose")
+var errFailOnPurpose = temporal.NewApplicationError("failing on purpose", temporal.ApplicationErrorType)
 
 func newActivities() *Activities {
 	activities2 := &Activities2{}

--- a/test/activity_test.go
+++ b/test/activity_test.go
@@ -46,7 +46,7 @@ type Activities2 struct {
 	impl *Activities
 }
 
-var errFailOnPurpose = temporal.NewApplicationError("failing on purpose", temporal.ApplicationErrorType)
+var errFailOnPurpose = temporal.NewApplicationError("failing on purpose", "")
 
 func newActivities() *Activities {
 	activities2 := &Activities2{}


### PR DESCRIPTION
`NewApplicationError` now has `type` argument which allows to specify error type explicitly. Use `temporal.ApplicationErrorType` for default type.

Plus few renames:
1. Field `originalType` -> `errType`
2. Func `OriginalType()` -> `Type()`
